### PR TITLE
testnet4 -> mainnet

### DIFF
--- a/bin/common.ts
+++ b/bin/common.ts
@@ -20,7 +20,7 @@ export function defineMainOptions() {
         .version('0.1.0')
         .option('--seeds <nodes...>', 'Connect to the following bootstrap nodes')
         .option('--peers <nodes...>', 'Include the following known peers')
-        .option('--chain <chain>', 'Bitcoin network', 'testnet4')
+        .option('--chain <chain>', 'Bitcoin network', 'mainnet')
         .option('--spaces-rpc-url <url>', 'Specify a spaces rpc url (default based on chain)');
 }
 

--- a/constants.ts
+++ b/constants.ts
@@ -2,6 +2,7 @@ import * as crypto from 'hypercore-crypto';
 
 export const BOOTSTRAP_NODES = [
   '107.152.45.120@testnet4.fabric.buffrr.dev:22253',
+  '70.251.209.207@mainnet.fabric.nostrops.space:22253',
 ]
 
 // Extend the existing COMMANDS from hyperdht/lib/constants

--- a/spaces.ts
+++ b/spaces.ts
@@ -86,7 +86,7 @@ export class Resolver {
     rpcUrl: URL;
 
     constructor(opts: ResolverOptions = {}) {
-        this.chain = opts.chain || 'testnet4';
+        this.chain = opts.chain || 'mainnet';
         this.rpcUrl = new URL(opts.rpcUrl || `http://localhost:${this.default_rpc_port()}`);
     }
 


### PR DESCRIPTION
Changed the default chain from testnet4 to mainnet now that mainnet launch has occurred.