### PR TITLE
Accept Nostr events for forward and reverse lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 | <img src="./logo.png" width="340"/> | <h1 align="left">Fabric</h1> <p align="left">Fabric is a free, open network that connects people and services without central control. Built on [hyperdht](https://github.com/holepunchto/hyperdht), it works with [Nostr](https://github.com/nostr-protocol/nostr) and [Spaces](https://spacesprotocol.org) to let you find someone by their sovereign handle (like `@example`) or by a public key (an `npub`).</p><br /> |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
+> [!WARNING]  
+> Fabric is an experimental project and will see frequent updates in the near future. Expect some bumps as we refine it—join us to shape its evolution!
 
 **Fabric makes it easy to share who you are or find others in a decentralized world.** It’s like an address book for the internet’s sovereign future—built on [hyperdht](https://github.com/holepunchto/hyperdht), it links [Nostr](https://github.com/nostr-protocol/nostr) messages and [Spaces](https://spacesprotocol.org) (sovereign handles, like `@example`) so anyone can look up a name or an npub without needing a middleman.
 
@@ -12,6 +14,9 @@
 
 
 Fabric enables [spaces](https://spacesprotocol.org) to publish Nostr events and DNS records on the DHT without needing to store any bloat on the Bitcoin blockchain!
+
+
+
 
 ## Installation
 
@@ -49,7 +54,9 @@ beam @buffrr TXT --remote-anchors https://bitpki.com/root-anchors.json
 
 Note: This means you’re trusting BitPKI (or whoever you pick) to provide accurate anchors file, so its best to run your own Bitcoin full node + [spaces client](https://github.com/spacesprotocol/spaces) locally to generate your own, and keep it up to date.
 
-## Publishing Records for a Space
+## Publishing events for a space
+
+A DNS zone could be wrapped in a Nostr event and signed for publishing, alternatively you may sign any accepted Nostr event and publish it for your space.
 
 1. **Create a DNS zone file** (e.g., `example.zone`):
 
@@ -78,6 +85,42 @@ beam publish event.json
 ```
 
 You can also distribute event.json to a Fabric service operator for continuous publication.
+
+## Publishing Nostr Events for Your `npub`
+
+For example, here’s how to sign and share a NIP-65 relay list tied to your `npub` (your public key):
+
+1. **Create the relay list** (sign & save as `nip65.json`):
+   ```json
+   {
+     "kind": 10002,
+     "created_at": 1679673265,
+     "pubkey": "97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322",
+     "tags": [
+       ["r", "wss://alicerelay.example.com"],
+       ["r", "wss://brando-relay.com"],
+       ["r", "wss://expensive-relay.example2.com", "write"],
+       ["r", "wss://nostr-relay.example.com", "read"]
+     ],
+     "content": "",
+     "sig": "<signature>"
+   }
+   ```
+
+2. **Publish it** with `beam`:
+
+```shell
+beam publish nip65.json
+```
+
+3. **Look it up:**
+
+```shell
+beam 97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322 10002
+```
+
+Records stay live on the network for up to 48 hours. To keep them active, re-publish periodically with the same command, or give it to some service to `pin` it for you.
+
 
 ## Running a Fabric Node
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 
 
 
-| <img src="./logo.png" width="340"/> | <h1 align="left">Fabric</h1> <p align="left">Fabric is a trustless, distributed DNS resolver for [spaces](https://spacesprotocol.org), enabling spaces to publish Bitcoin-signed zone files on a permissionless DHT without storing anything on-chain!</p><br /> |
-|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <img src="./logo.png" width="340"/> | <h1 align="left">Fabric</h1> <p align="left">Fabric is a free, open network that connects people and services without central control. Built on [hyperdht](https://github.com/holepunchto/hyperdht), it works with [Nostr](https://github.com/nostr-protocol/nostr) and [Spaces](https://spacesprotocol.org) to let you find someone by their sovereign handle (like `@example`) or by a public key (an `npub`).</p><br /> |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
 
-Fabric is a trustless, distributed DNS resolver built on top of [hyperdht](https://github.com/holepunchto/hyperdht). It lets you publish signed DNS zone files for [spaces](https://spacesprotocol.org)—sovereign Bitcoin identities—off-chain, without adding on-chain bloat.
+**Fabric makes it easy to share who you are or find others in a decentralized world.** It’s like an address book for the internet’s sovereign future—built on [hyperdht](https://github.com/holepunchto/hyperdht), it links [Nostr](https://github.com/nostr-protocol/nostr) messages and [Spaces](https://spacesprotocol.org) (sovereign handles, like `@example`) so anyone can look up a name or an npub without needing a middleman.
 
+
+**Note:** Fabric is not a replacement for Nostr relays! It's intended for publishing small pieces of discovery information. For example, you could share a [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) relay list for your npub! Fabric accepts replaceable and addressable Nostr events.
+
+
+Fabric enables [spaces](https://spacesprotocol.org) to publish Nostr events and DNS records on the DHT without needing to store any bloat on the Bitcoin blockchain!
 
 ## Installation
 
@@ -15,53 +20,70 @@ Fabric is a trustless, distributed DNS resolver built on top of [hyperdht](https
 npm install -g @spacesprotocol/fabric
 ```
 
+## Querying Fabric with beam
 
-## Querying Spaces with beam
+`beam` is a query tool and publisher.
 
+1. Querying Nostr events:
 
-The `beam` tool is your distributed `dig` and publisher.
+```
+beam <pubkey_or_space> <event kind> <optional-d-tag>
+```
 
+2. Querying DNS records
 ```
 beam @buffrr TXT
 ```
 
-By default, `beam` loads trust anchors from `http://127.0.0.1:7225/root-anchors.json` to verify responses (assuming a [spaces](https://github.com/spacesprotocol/spaces) client is running & connected to Bitcoin core). You can override this with:
+By default, beam grabs a list of trust anchors from your local spaces client at http://127.0.0.1:7225/root-anchors.json to verify spaces. This works if you’re running a [spaces client](https://github.com/spacesprotocol/spaces) with Bitcoin Core locally. But if you just want to try out Fabric, you can use an external service instead:
 
-- A local anchors file: `--local-anchors /path/to/root-anchors.json`
-- A remote anchors URL: `--remote-anchors https://example.com/root-anchors.json`
-  (or by setting `FABRIC_REMOTE_ANCHORS` environment variable)
+```shell
+export FABRIC_REMOTE_ANCHORS=https://bitpki.com/root-anchors.json
+```
 
+Or add it when you run beam:
+
+```shell
+beam @buffrr TXT --remote-anchors https://bitpki.com/root-anchors.json
+```
+
+Note: This means you’re trusting BitPKI (or whoever you pick) to provide accurate anchors file, so its best to run your own Bitcoin full node + [spaces client](https://github.com/spacesprotocol/spaces) locally to generate your own, and keep it up to date.
 
 ## Publishing Records for a Space
 
 1. **Create a DNS zone file** (e.g., `example.zone`):
 
-       @example. 3600 CLASS2 SOA . . ( 1 3600 600 604800 3600 )
-       @example. 3600 CLASS2 A   127.0.0.1
-       @example. 3600 CLASS2 TXT "hello world"
+```
+@example. 3600 CLASS2 A   127.0.0.1
+@example. 3600 CLASS2 TXT "hello world"
+```
 
 2. **Sign the zone file** with `space-cli`:
 
-       space-cli signzone example.zone
+```
+space-cli signzone @example example.zone > event.json
+```
 
-   This produces `example.packet.json`.
+3. **Publish** with beam:
 
-3. **Publish the packet** with beam:
-
-       beam publish example.packet.json
+```
+beam publish event.json
+```
 
 The network retains records for up to 48 hours. To refresh, run:
 
-       space-cli refreshpacket example.packet.json
-       beam publish example.packet.json
+```
+space-cli refreshanchor event.json
+beam publish event.json
+```
 
-You can also distribute the signed packet (`example.packet.json`) to a Fabric service operator for continuous publication.
+You can also distribute event.json to a Fabric service operator for continuous publication.
 
 ## Running a Fabric Node
 
 To contribute to the network, run a Fabric node by specifying a reachable IP and port:
 
-    fabric --host <ip-address> --port <public-port>
+    fabric --host <public-ip-address> --port <public-port>
 
 After about 30 minutes of uptime, your node becomes persistent.
 
@@ -71,9 +93,16 @@ We welcome more bootstrap nodes. To contribute:
 
 1. Run a node with a reachable IP/port using the `--bootstrap` flag:
 
-       fabric --host <ip-address> --port <port> --bootstrap
+       fabric --host <public-ip-address> --port <public-port> --bootstrap
 
 2. Submit a pull request updating `constants.js` with your node’s details.
+
+
+## How does Fabric verify spaces?
+
+1. The [Spaces client](https://github.com/spacesprotocol/spaces) performs Client Side Validation (CSV) reading Bitcoin blocks and verifying the protocol state, summarizing it all into a Merkle tree root
+2. The client generates a trust anchors file that's used by Fabric to verify PUT requests.
+
 
 ## Encrypted Noise Connections
 

--- a/anchor.ts
+++ b/anchor.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import {Veritas, SLabel} from '@spacesprotocol/veritas';
 import b4a from 'b4a';
 import {EventRecord, CompactEvent, signableCompactEvent, TargetInfo} from './messages';
+import {log} from './utils';
 
 interface Anchor {
     root: string;
@@ -55,7 +56,7 @@ export class AnchorStore {
       this.fileWatcher = fs.watch(this.options.localPath!, (eventType) => {
         if (eventType === 'change') {
           this.refreshAnchors().catch(err => {
-            console.error(`Error refreshing anchors on file change: ${err}`);
+            log(`Error refreshing anchors on file change: ${err}`);
           });
         }
       });
@@ -66,7 +67,7 @@ export class AnchorStore {
       const interval = this.options.checkIntervalMs ?? defaultCheckInterval;
       this.intervalId = setInterval(() => {
         this.refreshAnchors().catch(err => {
-          console.error(`Error during periodic refresh: ${err}`);
+          log(`Error during periodic refresh: ${err}`);
         });
       }, interval);
     }
@@ -163,7 +164,7 @@ export class AnchorStore {
         this.updateAnchors(anchors);
         return;
       } catch (err) {
-        console.error(`Failed to read or parse local anchors file: ${err}`);
+        log(`Failed to read or parse local anchors file: ${err}`);
       }
     }
 
@@ -190,7 +191,7 @@ export class AnchorStore {
         return await this.fetchAnchorsFromRemotes(this.options.remoteUrls!);
       } catch (err) {
         attempts++;
-        console.error(`${err}.` + (attempts < maxRetries ? ` Retrying in ${delayMs}ms...` : ''));
+        log(`${err}.` + (attempts < maxRetries ? ` Retrying in ${delayMs}ms...` : ''));
         await new Promise(resolve => setTimeout(resolve, delayMs));
       }
     }
@@ -200,7 +201,7 @@ export class AnchorStore {
   private async fetchAnchorsFromRemotes(remoteUrls: string[]): Promise<Anchor[]> {
     const responses = await Promise.all(
       remoteUrls.map(async url => {
-        console.log(`Fetching anchors from: ${url}`);
+        log(`Fetching anchors from: ${url}`);
         try {
           const res = await fetch(url);
           if (!res.ok) {
@@ -208,7 +209,7 @@ export class AnchorStore {
           }
           return res.json();
         } catch (err) {
-          console.error(`Error fetching ${url}: ${err}`);
+          log(`Error fetching ${url}: ${err}`);
           return null;
         }
       })
@@ -274,6 +275,6 @@ export class AnchorStore {
       this.trustPoints.set(anchor.root, anchor.block.height);
     }
 
-    console.log(`Anchors refreshed, latest block ${anchors[0].block.height}`);
+    log(`Anchors refreshed, latest block ${anchors[0].block.height}`);
   }
 }

--- a/bin/beam.ts
+++ b/bin/beam.ts
@@ -5,7 +5,7 @@ import {defineMainOptions, nodeOpts} from './common';
 import fs from 'fs';
 import {Fabric} from '../index';
 import dns from 'dns-packet';
-import {NostrEvent, validateEvent} from '../utils';
+import {log, NostrEvent, validateEvent} from '../utils';
 import {basename, resolve} from 'node:path';
 import {KeyPair} from 'hypercore-crypto';
 import {Buffer} from 'buffer';

--- a/bin/common.ts
+++ b/bin/common.ts
@@ -1,6 +1,6 @@
 import { program } from 'commander';
 import { FabricOptions } from '../index';
-import { VeritasSync } from '../veritas';
+import { AnchorStore } from '../anchor';
 
 export interface MainOptions {
     host?: string;
@@ -23,8 +23,8 @@ export function defineMainOptions() {
     .option('--port <port>', 'The port to bind to')
     .option('--seeds <nodes...>', 'Connect to the following bootstrap nodes')
     .option('--peers <nodes...>', 'Include the following known peers')
-    .option('--local-anchors <local>', 'Specify a local file to sync anchors')
-    .option('--remote-anchors <remote...>', 'Specify remote urls to sync anchors');
+    .option('--local-anchors <local>', 'Specify a local file to load anchors')
+    .option('--remote-anchors <remote...>', 'Specify remote urls to load anchors');
 }
 
 export async function nodeOpts(opts: MainOptions): Promise<FabricOptions> {
@@ -50,11 +50,11 @@ export async function nodeOpts(opts: MainOptions): Promise<FabricOptions> {
         };
       })
       : [],
-    veritas: await veritasFromOpts(opts),
+    anchor: await anchorFromOpts(opts),
   };
 }
 
-export async function veritasFromOpts(opts: MainOptions): Promise<VeritasSync> {
+export async function anchorFromOpts(opts: MainOptions): Promise<AnchorStore> {
   const localAnchors = opts.localAnchors || process.env.FABRIC_LOCAL_ANCHORS;
   const remoteAnchors =
         opts.remoteAnchors ||
@@ -62,12 +62,13 @@ export async function veritasFromOpts(opts: MainOptions): Promise<VeritasSync> {
           ? process.env.FABRIC_REMOTE_ANCHORS.split(',')
           : ['http://127.0.0.1:7225/root-anchors.json']);
 
-  return VeritasSync.create({
+  return AnchorStore.create({
     localPath: localAnchors,
     remoteUrls: remoteAnchors,
   });
 }
 
-export function joinHostPort(address: Address): string {
+export function joinHostPort(address: Address | null): string {
+  if (!address) return '--';
   return `${address?.host}:${address?.port}`;
 }

--- a/bin/fabric.ts
+++ b/bin/fabric.ts
@@ -29,6 +29,10 @@ async function main(opts: FabricOptions): Promise<void> {
     node = Fabric.bootstrapper(Number(opts.port) || 0, opts.host, opts);
   } else {
     console.log('Starting Fabric node...');
+    if (typeof opts.port === 'number' && opts.port !== 0) {
+      // @ts-ignore
+      opts.firewalled = false;
+    }
     node = new Fabric(opts);
   }
 
@@ -45,8 +49,8 @@ async function main(opts: FabricOptions): Promise<void> {
   });
 
   await node.ready();
+  console.log('Listening at:', joinHostPort(node.address()));
 
-  console.log('Node ready');
   process.once('SIGINT', function () {
     node.destroy();
   });

--- a/bin/fabric.ts
+++ b/bin/fabric.ts
@@ -4,6 +4,7 @@ import {InvalidOptionArgumentError, program} from 'commander';
 import {Fabric, FabricOptions} from '../index';
 import {defineMainOptions, MainOptions, nodeOpts, joinHostPort} from './common';
 import {DHT} from 'dht-rpc';
+import {log} from '../utils';
 
 defineMainOptions();
 
@@ -15,7 +16,6 @@ program.parse();
 
 const opts = program.opts();
 
-
 async function main(opts: FabricOptions): Promise<void> {
   let node: Fabric | DHT;
   const bootstrap = opts.bootstrap;
@@ -25,10 +25,10 @@ async function main(opts: FabricOptions): Promise<void> {
     if (!opts.host) throw new InvalidOptionArgumentError('You need to specify a public --host <node ip> for the bootstrap node');
     if (!opts.port || isNaN(Number(opts.port))) throw new InvalidOptionArgumentError('You need to specify a valid --port <port> for the bootstrap node');
 
-    console.log('Starting Fabric bootstrap node...');
+    log('Starting Fabric bootstrap node...');
     node = Fabric.bootstrapper(Number(opts.port) || 0, opts.host, opts);
   } else {
-    console.log('Starting Fabric node...');
+    log('Starting Fabric node...');
     if (typeof opts.port === 'number' && opts.port !== 0) {
       // @ts-ignore
       opts.firewalled = false;
@@ -37,19 +37,19 @@ async function main(opts: FabricOptions): Promise<void> {
   }
 
   node.on('ephemeral', function () {
-    console.log('Node is ephemeral', node.address());
+    log('Node is ephemeral', node.address());
   });
 
   node.on('persistent', function () {
-    console.log('Node is persistent, joining remote routing tables');
+    log('Node is persistent, joining remote routing tables');
   });
 
   node.on('close', function () {
-    console.log('Node closed');
+    log('Node closed');
   });
 
   await node.ready();
-  console.log('Listening at:', joinHostPort(node.address()));
+  log('Listening at:', joinHostPort(node.address()));
 
   process.once('SIGINT', function () {
     node.destroy();

--- a/constants.ts
+++ b/constants.ts
@@ -14,8 +14,8 @@ export const COMMANDS = {
   MUTABLE_GET: 7,
   IMMUTABLE_PUT: 8,
   IMMUTABLE_GET: 9,
-  ZONE_PUT: 20,
-  ZONE_GET: 21,
-  NOSTR_PUT: 22,
-  NOSTR_GET: 24,
+  EVENT_PUT: 22,
+  EVENT_GET: 24,
 };
+
+export const DNS_EVENT_KIND = 871222;

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,3 @@
-import * as crypto from 'hypercore-crypto';
-
 export const BOOTSTRAP_NODES = [
   '107.152.45.120@fabric.buffrr.dev:22253',
 ]
@@ -17,13 +15,7 @@ export const COMMANDS = {
   IMMUTABLE_PUT: 8,
   IMMUTABLE_GET: 9,
   ZONE_PUT: 20,
-  ZONE_GET: 21
-};
-
-const [NS_ZONE_PUT] = crypto.namespace('hyperswarm/dht', [
-  COMMANDS.ZONE_PUT
-]);
-
-export const NS = {
-  ZONE_PUT: NS_ZONE_PUT
+  ZONE_GET: 21,
+  NOSTR_PUT: 22,
+  NOSTR_GET: 24,
 };

--- a/example/resolve.ts
+++ b/example/resolve.ts
@@ -23,10 +23,15 @@ async function main() {
     })
   });
 
+  // Fetching spaces/forward lookups
   const {value : dnsPacket} = await fabric.zoneGet('@buffrr');
   const records = dns.decode(dnsPacket);
   console.log('records: ', records);
   await fabric.destroy();
+
+  // Nostr (reverse lookups by npub)
+  // Nostr events: await fabric.nostrGet('<npub>', <kind>, '<optional-d-tag>')
+  // Publish nostr events: await fabric.nostrPublish(jsonEvent);
 }
 
 main();

--- a/example/resolve.ts
+++ b/example/resolve.ts
@@ -7,7 +7,9 @@ async function main() {
     // Load trust anchors
     veritas: await VeritasSync.create({
       remoteUrls: ['http://127.0.0.1:7225/root-anchors.json'],
-      // Alternatively specify static ones
+      // OR use a public service e.g.
+      // remoteUrls: ['https://bitpki.com/root-anchors.json']
+      // Alternatively specify static ones (must be updated periodically to allow new spaces)
       // staticAnchors: [
       //   {
       //     root: 'c9395f0256c5f665f30f191af459836f92073901f609d1dc6db0bc8787d82dbf',

--- a/index.ts
+++ b/index.ts
@@ -6,9 +6,10 @@ import b4a from 'b4a';
 import * as m from './messages';
 import {DHT} from 'dht-rpc';
 import {Receipt, VeritasSync} from './veritas';
-import {spaceHash} from './utils';
+import {nostrTarget, NostrEvent, serializeEvent, spaceHash, nostrDTag} from './utils';
 
-const defaultMaxSize = 32768;
+
+const defaultCacheMaxSize = 32768;
 const defaultMaxAge = 48 * 60 * 60 * 1000; // 48 hours
 
 export const ERROR = {
@@ -26,6 +27,11 @@ export const ERROR = {
   NO_MATCHING_TRUST_ANCHOR: 26,
   NON_STALE_ANCESTOR_EXISTS: 27,
   STALE_PROOF: 28,
+  // nostr related
+  EVENT_MALFORMED: 40,
+  EVENT_UNSUPPORTED: 41,
+  EVENT_TOO_NEW: 42,
+  EVENT_TOO_OLD: 43,
 };
 
 export const ERROR_STRING: Record<number, string> = {
@@ -42,17 +48,24 @@ export const ERROR_STRING: Record<number, string> = {
   [ERROR.NO_MATCHING_TRUST_ANCHOR]: 'no matching trust path',
   [ERROR.NON_STALE_ANCESTOR_EXISTS]: 'non-stale ancestor trust path exists',
   [ERROR.STALE_PROOF]: 'stale trust path',
+  // nostr related
+  [ERROR.EVENT_MALFORMED]: 'event malformed',
+  [ERROR.EVENT_UNSUPPORTED]: 'event unsupported',
+  [ERROR.EVENT_TOO_NEW]: 'event too far in the future',
+  [ERROR.EVENT_TOO_OLD]: 'event too old',
 };
 
 export interface FabricOptions extends HyperDHTOptions {
     maxSize?: number;
     maxAge?: number;
     zones?: MaxCacheOptions;
+    nostr?: MaxCacheOptions;
     veritas?: VeritasSync;
 }
 
 export class Fabric extends HyperDHT {
   private _zones: Cache | null = null;
+  private _nostr: Cache | null = null;
   public veritas: VeritasSync;
 
   constructor(opts: FabricOptions = {}) {
@@ -61,7 +74,11 @@ export class Fabric extends HyperDHT {
 
     this.once('persistent', () => {
       this._zones = new Cache(opts.zones || {
-        maxSize: opts.maxSize || defaultMaxSize,
+        maxSize: opts.maxSize || defaultCacheMaxSize,
+        maxAge: opts.maxAge || defaultMaxAge,
+      });
+      this._nostr = new Cache(opts.nostr || {
+        maxSize: opts.maxSize || defaultCacheMaxSize,
         maxAge: opts.maxAge || defaultMaxAge,
       });
     });
@@ -72,6 +89,46 @@ export class Fabric extends HyperDHT {
 
   static bootstrapper(port: number, host: string, opts?: FabricOptions): DHT {
     return super.bootstrapper(port, host, opts)
+  }
+
+  async nostrPublish(evt: NostrEvent, opts: any = {}) {
+    const value = b4a.from(serializeEvent(evt), 'utf-8');
+    if (!evt.sig) throw new Error('must be a signed nostr event');
+    let signature = b4a.from(evt.sig, 'hex');
+    const targetString = nostrTarget(evt.pubkey, evt.kind, nostrDTag(evt.tags));
+    if (!targetString) throw new Error('invalid nostr event - could not find target string')
+    const target = this.veritas.sha256(b4a.from(targetString));
+    const publicKey = b4a.from(evt.pubkey, 'hex');
+
+    if (!opts.skipVerify)
+      this.veritas.verifySchnorr(publicKey, this.veritas.sha256(value), signature);
+
+    const signed = c.encode(m.nostrPutRequest, {publicKey, signature, value})
+    opts = {
+      ...opts,
+      map: mapNostr,
+      commit(reply: any, dht: any) {
+        const q = async () => {
+          const q = await dht.request({
+            token: reply.token,
+            target,
+            command: COMMANDS.NOSTR_PUT,
+            value: signed,
+          }, reply.from);
+          if (q.error !== 0) {
+            const err = ERROR_STRING[q.error] || 'unknown';
+            throw new Error(`put request failed - ${err} (code: ${q.error})`);
+          }
+          return q;
+        };
+        return q();
+      },
+    };
+
+    const query = this.query({target, command: COMMANDS.NOSTR_GET, value: c.encode(c.uint, 0)}, opts);
+    await query.finished();
+
+    return {target, closestNodes: query.closestNodes, signature};
   }
 
   async zonePublish(space: string, value: Buffer, signature: Buffer, proof: Buffer, opts: any = {}) {
@@ -123,7 +180,7 @@ export class Fabric extends HyperDHT {
       if (node.seq < userSeq) continue;
       const msg = c.encode(m.zoneSignable, {seq: node.seq, value: node.value});
       try {
-        const receipt = this.veritas.verifyPut(target, msg, node.signature, node.proof);
+        const receipt = this.veritas.verifyZone(target, msg, node.signature, node.proof);
         if (!latest) {
           result = node;
           result.proofSeq = receipt.proofSeq;
@@ -168,13 +225,128 @@ export class Fabric extends HyperDHT {
     }
   }
 
-  destroy(opts?: { force?: boolean }): Promise<void> {
-    super.destroy(opts);
-    this.veritas.destroy()
-    return Promise.resolve()
+  async nostrGet(pubkey: Uint8Array, kind: number, d : string = '', opts: any = {}) {
+    if (pubkey.length !== 32) throw new Error(`invalid pubkey length ${pubkey.length}`)
+    const targetString = nostrTarget(b4a.toString(pubkey, 'hex'), kind, d);
+    const target = this.veritas.sha256(b4a.from(targetString));
+    let refresh = opts.refresh || null;
+    let signed: Buffer | Uint8Array | null = null;
+    let result: any = null;
+    opts = {...opts, map: mapNostr, commit: refresh ? commit : null};
+
+    const userCreatedAt = opts.createdAt || 0;
+    const query = this.query({target, command: COMMANDS.NOSTR_GET, value: c.encode(c.uint, userCreatedAt)}, opts);
+    const latest = opts.latest !== false;
+    const closestNodes: Buffer[] = [];
+
+    for await (const node of query) {
+      closestNodes.push(node.from);
+      if (result && node.seq <= result.seq) continue;
+      if (node.createdAt < userCreatedAt) continue;
+      try {
+        this.veritas.verifyNostr(target, node.value, pubkey, node.signature);
+        if (!latest) {
+          result = node;
+          break;
+        }
+        if (!result || (node.createdAt > result.createdAt)) result = node;
+      } catch (e) {
+        console.warn(`Could not verify from peer ${node.from.host}:${node.from.port}: ${e}`);
+      }
+    }
+    if (!result) {
+      return null;
+    }
+
+    closestNodes.splice(closestNodes.indexOf(result.from), 1);
+    result.closestNodes = closestNodes;
+
+    return result;
+
+    function commit(reply: any, dht: Fabric) {
+      if (!signed && result && refresh) {
+        if (refresh(result)) {
+          signed = c.encode(m.nostrPutRequest, {
+            value: result.value,
+            publicKey: result.publicKey,
+            signature: result.signature,
+          });
+        } else {
+          refresh = null;
+        }
+      }
+
+      return signed
+        ? dht.request({
+          token: reply.token,
+          target,
+          command: COMMANDS.NOSTR_PUT,
+          value: signed,
+        }, reply.from)
+        : Promise.resolve(null);
+    }
   }
 
+  onnostrput(req: any) {
+    if (!req.target || !req.token || !req.value) return;
 
+    const p = decode(m.nostrPutRequest, req.value);
+    if (!p) return;
+
+    const {value, publicKey, signature} = p;
+    if (!value) return;
+
+    if (req.target.length !== 32) return;
+    let evtCreatedAt : number;
+    try {
+      evtCreatedAt = this.veritas.verifyNostr(req.target, value, publicKey, signature);
+    } catch (e) {
+      console.error(e)
+      req.error(ERROR.EVENT_MALFORMED)
+      return;
+    }
+
+    const k = b4a.toString(req.target, 'hex');
+    const local = this._nostr?.get(k);
+    if (local) {
+      const existing = c.decode(m.nostrRecord, local);
+      if (existing.createdAt > evtCreatedAt) {
+        req.error(ERROR.EVENT_TOO_OLD);
+        return;
+      }
+    }
+
+    console.log(`nostrPut: storing ${req.target.toString('hex')}`);
+    this._nostr?.set(k, c.encode(m.nostrRecord, {
+      value,
+      signature,
+      publicKey,
+      createdAt: evtCreatedAt
+    }));
+    req.reply(null);
+  }
+
+  onnostrget(req: any) {
+    if (!req.target || !req.value) return;
+
+    let createdAt = 0;
+    try {
+      createdAt = c.decode(c.uint, req.value);
+    } catch {
+      return;
+    }
+
+    const k = b4a.toString(req.target, 'hex');
+    const value = this._nostr?.get(k);
+
+    if (!value) {
+      req.reply(null);
+      return;
+    }
+
+    const localCreatedAt = c.decode(c.uint, value);
+    req.reply(localCreatedAt < createdAt ? null : value);
+  }
 
   onzoneput(req: any) {
     if (!req.target || !req.token || !req.value) return;
@@ -190,7 +362,7 @@ export class Fabric extends HyperDHT {
     let publicKey : Uint8Array | undefined;
     try {
       // Validate the proof first.
-      receipt = this.veritas.verifyPut(req.target, msg, signature, proof);
+      receipt = this.veritas.verifyZone(req.target, msg, signature, proof);
       publicKey = receipt.spaceout.getPublicKey();
       if (!publicKey) throw new Error('Expected a public key');
     } catch (e: any) {
@@ -204,7 +376,7 @@ export class Fabric extends HyperDHT {
     const k = b4a.toString(req.target, 'hex');
     const local = this._zones?.get(k);
     if (local) {
-      const existing = c.decode(m.zoneGetResponse, local);
+      const existing = c.decode(m.zoneRecord, local);
       const identical = existing.value && b4a.compare(value, existing.value) === 0;
       const existingProofSeq = this.veritas.getProofSeq(existing.root);
 
@@ -251,7 +423,7 @@ export class Fabric extends HyperDHT {
     }
 
     console.log(`zonePut: storing ${req.target.toString('hex')}`);
-    this._zones?.set(k, c.encode(m.zoneGetResponse, {
+    this._zones?.set(k, c.encode(m.zoneRecord, {
       seq,
       value,
       signature,
@@ -295,9 +467,21 @@ export class Fabric extends HyperDHT {
     case COMMANDS.ZONE_GET:
       this.onzoneget(req);
       return true;
+    case COMMANDS.NOSTR_PUT:
+      this.onnostrput(req);
+      return true;
+    case COMMANDS.NOSTR_GET:
+      this.onnostrget(req);
+      return true;
     default:
       return super.onrequest(req);
     }
+  }
+
+  destroy(opts?: { force?: boolean }): Promise<void> {
+    super.destroy(opts);
+    this.veritas.destroy()
+    return Promise.resolve()
   }
 }
 
@@ -313,7 +497,7 @@ function mapZone(node: any) {
   if (!node.value) return null;
 
   try {
-    const {seq, value, signature, proof} = c.decode(m.zoneGetResponse, node.value);
+    const {seq, value, signature, proof} = c.decode(m.zoneRecord, node.value);
 
     return {
       token: node.token,
@@ -323,6 +507,26 @@ function mapZone(node: any) {
       value,
       signature,
       proof
+    };
+  } catch {
+    return null;
+  }
+}
+
+function mapNostr(node: any) {
+  if (!node.value) return null;
+
+  try {
+    const {createdAt, value, publicKey, signature} = c.decode(m.nostrRecord, node.value);
+
+    return {
+      token: node.token,
+      from: node.from,
+      to: node.to,
+      publicKey,
+      createdAt,
+      value,
+      signature,
     };
   } catch {
     return null;

--- a/index.ts
+++ b/index.ts
@@ -5,28 +5,32 @@ import {BOOTSTRAP_NODES, COMMANDS} from './constants';
 import b4a from 'b4a';
 import * as m from './messages';
 import {DHT} from 'dht-rpc';
-import {Receipt, VeritasSync} from './veritas';
-import {nostrTarget, NostrEvent, serializeEvent, spaceHash, nostrDTag} from './utils';
+import {AnchorStore} from './anchor';
+import {
+  NostrEvent,
+  verifyTarget,
+  computeTarget,
+  computeSpaceTarget, computePubkeyTarget, isAcceptableEvent
+} from './utils';
 import {Buffer} from 'buffer';
-
+import {CompactEvent, toCompactEvent} from './messages';
 
 const defaultCacheMaxSize = 32768;
 const defaultMaxAge = 48 * 60 * 60 * 1000; // 48 hours
 
-export interface SignedPacket {
-  space: string;
-  serial: number;
-  signature: Buffer;
-  value: Buffer;
-  proof: Buffer;
+interface NodeResposne {
+  token: any
+  from: any,
+  to: any,
+  event: CompactEvent
 }
 
 export interface FabricOptions extends HyperDHTOptions {
-  maxSize?: number;
-  maxAge?: number;
-  zones?: MaxCacheOptions;
-  nostr?: MaxCacheOptions;
-  veritas?: VeritasSync;
+    maxSize?: number;
+    maxAge?: number;
+    spaces?: MaxCacheOptions;
+    pubkeys?: MaxCacheOptions;
+    anchor?: AnchorStore;
 }
 
 export const ERROR = {
@@ -40,15 +44,10 @@ export const ERROR = {
   SEQ_REUSED: 16,
   SEQ_TOO_LOW: 17,
   // space related
-  INVALID_SIGNATURE: 25,
-  NO_MATCHING_TRUST_ANCHOR: 26,
-  NON_STALE_ANCESTOR_EXISTS: 27,
-  STALE_PROOF: 28,
-  // nostr related
-  EVENT_MALFORMED: 40,
-  EVENT_UNSUPPORTED: 41,
-  EVENT_TOO_NEW: 42,
-  EVENT_TOO_OLD: 43,
+  EVENT_ANCHOR_REJECTED: 40,
+  EVENT_UNSUPPORTED: 42,
+  EVENT_TOO_NEW: 44,
+  EVENT_TOO_OLD: 45,
 };
 
 export const ERROR_STRING: Record<number, string> = {
@@ -61,69 +60,61 @@ export const ERROR_STRING: Record<number, string> = {
   [ERROR.SEQ_REUSED]: 'sequence reused',
   [ERROR.SEQ_TOO_LOW]: 'sequence too low',
   // fabric related
-  [ERROR.INVALID_SIGNATURE]: 'invalid signature',
-  [ERROR.NO_MATCHING_TRUST_ANCHOR]: 'no matching trust path',
-  [ERROR.NON_STALE_ANCESTOR_EXISTS]: 'non-stale ancestor trust path exists',
-  [ERROR.STALE_PROOF]: 'stale trust path',
-  // nostr related
-  [ERROR.EVENT_MALFORMED]: 'event malformed',
-  [ERROR.EVENT_UNSUPPORTED]: 'event unsupported',
+  [ERROR.EVENT_ANCHOR_REJECTED]: 'event anchor rejected',
   [ERROR.EVENT_TOO_NEW]: 'event too far in the future',
   [ERROR.EVENT_TOO_OLD]: 'event too old',
 };
 
-
 export class Fabric extends HyperDHT {
-  private _zones: Cache | null = null;
-  private _nostr: Cache | null = null;
-  public veritas: VeritasSync;
+  private _spaces: Cache | null = null;
+  private _pubkeys: Cache | null = null;
+  public anchor: AnchorStore;
 
   constructor(opts: FabricOptions = {}) {
     opts.bootstrap = opts.bootstrap || BOOTSTRAP_NODES
     super(opts);
 
     this.once('persistent', () => {
-      this._zones = new Cache(opts.zones || {
+      this._spaces = new Cache(opts.spaces || {
         maxSize: opts.maxSize || defaultCacheMaxSize,
         maxAge: opts.maxAge || defaultMaxAge,
       });
-      this._nostr = new Cache(opts.nostr || {
+      this._pubkeys = new Cache(opts.pubkeys || {
         maxSize: opts.maxSize || defaultCacheMaxSize,
         maxAge: opts.maxAge || defaultMaxAge,
       });
     });
 
-    if (!opts.veritas) throw new Error('Veritas options are required');
-    this.veritas = opts.veritas;
+    if (!opts.anchor) throw new Error('Anchor setup is required');
+    this.anchor = opts.anchor;
   }
 
   static bootstrapper(port: number, host: string, opts?: FabricOptions): DHT {
     return super.bootstrapper(port, host, opts)
   }
 
-  async nostrPublish(evt: NostrEvent, opts: any = {}) {
-    const value = b4a.from(serializeEvent(evt), 'utf-8');
-    if (!evt.sig) throw new Error('must be a signed nostr event');
-    let signature = b4a.from(evt.sig, 'hex');
-    const targetString = nostrTarget(evt.pubkey, evt.kind, nostrDTag(evt.tags));
-    if (!targetString) throw new Error('invalid nostr event - could not find target string')
-    const target = this.veritas.sha256(b4a.from(targetString));
-    const publicKey = b4a.from(evt.pubkey, 'hex');
+  async eventPut(evt: NostrEvent, opts: any = {}) : Promise<any> {
+    if (!isAcceptableEvent(evt.kind)) throw new Error('Event kind not supported');
+    const raw = toCompactEvent(evt, opts.binary || false);
+    const p: CompactEvent | null = c.decode(m.compactEvent, raw);
+    if (!p) throw new Error('Could not decode event');
 
-    if (!opts.skipVerify)
-      this.veritas.verifySchnorr(publicKey, this.veritas.sha256(value), signature);
+    const targetInfo = computeTarget(p);
+    if (!opts.skipVerify) {
+      if (!this.anchor.verifySig(p)) throw new Error('signature verification failed');
+    }
+    if (targetInfo.space) this.anchor.assertAnchored(p, targetInfo);
 
-    const signed = c.encode(m.nostrPutRequest, {publicKey, signature, value})
     opts = {
       ...opts,
-      map: mapNostr,
+      map: mapEvent,
       commit(reply: any, dht: any) {
         const q = async () => {
           const q = await dht.request({
             token: reply.token,
-            target,
-            command: COMMANDS.NOSTR_PUT,
-            value: signed,
+            target: targetInfo.target,
+            command: COMMANDS.EVENT_PUT,
+            value: raw,
           }, reply.from);
           if (q.error !== 0) {
             const err = ERROR_STRING[q.error] || 'unknown';
@@ -135,137 +126,40 @@ export class Fabric extends HyperDHT {
       },
     };
 
-    const query = this.query({target, command: COMMANDS.NOSTR_GET, value: c.encode(c.uint, 0)}, opts);
+    const query = this.query({target: targetInfo.target, command: COMMANDS.EVENT_GET, value: c.encode(c.uint, 0)}, opts);
     await query.finished();
 
-    return {target, closestNodes: query.closestNodes, signature};
+    return {target: targetInfo.target, closestNodes: query.closestNodes, event: p};
   }
+  
+  async eventGet(spaceOrPubkey : string, kind : number, d : string = '', opts : any = {}) : Promise<any> {
+    if (!isAcceptableEvent(kind)) throw new Error('Event kind not supported');
+    const target = spaceOrPubkey.startsWith('@') ? computeSpaceTarget(spaceOrPubkey, kind, d) :
+      computePubkeyTarget(spaceOrPubkey, kind, d);
 
-  async zonePublish(packet: SignedPacket, opts: any = {}) {
-    const target = spaceHash(packet.space);
-    const signable = c.encode(m.zoneSignable, {serial: packet.serial, value: packet.value});
-    // Throws on failure
-    this.veritas.verifyZone(target, signable, packet.signature, packet.proof);
-    const signed = c.encode(m.zonePutRequest, {serial: packet.serial, value: packet.value, signature: packet.signature, proof: packet.proof});
-    opts = {
-      ...opts,
-      map: mapZone,
-      commit(reply: any, dht: any) {
-        const q = async () => {
-          const q = await dht.request({
-            token: reply.token,
-            target,
-            command: COMMANDS.ZONE_PUT,
-            value: signed,
-          }, reply.from);
-          if (q.error !== 0) {
-            const err = ERROR_STRING[q.error] || 'unknown';
-            throw new Error(`put request failed - ${err} (code: ${q.error})`);
-          }
-          return q;
-        };
-        return q();
-      },
-    };
-
-    const query = this.query({target, command: COMMANDS.ZONE_GET, value: c.encode(c.uint, 0)}, opts);
-    await query.finished();
-
-    return {target, closestNodes: query.closestNodes, serial: packet.serial, signature: packet.signature};
-  }
-
-  async zoneGet(space: string, opts: any = {}) {
-    const target = spaceHash(space);
     let refresh = opts.refresh || null;
     let signed: Buffer | Uint8Array | null = null;
     let result: any = null;
-    opts = {...opts, map: mapZone, commit: refresh ? commit : null};
+    opts = {...opts, map: mapEvent, commit: refresh ? commit : null};
 
-    const userSerial = opts.serial || 0;
-    const query = this.query({target, command: COMMANDS.ZONE_GET, value: c.encode(c.uint, userSerial)}, opts);
+    const userCreatedAt = opts.created_at || 0;
+    const query = this.query({target, command: COMMANDS.EVENT_GET, value: c.encode(c.uint, userCreatedAt)}, opts);
     const latest = opts.latest !== false;
     const closestNodes: Buffer[] = [];
-
-    for await (const node of query) {
-      closestNodes.push(node.from);
-      if (result && node.serial <= result.serial) continue;
-      if (node.serial < userSerial) continue;
-      const msg = c.encode(m.zoneSignable, {serial: node.serial, value: node.value});
-      try {
-        const receipt = this.veritas.verifyZone(target, msg, node.signature, node.proof);
-        if (!latest) {
-          result = node;
-          result.trustpoint = receipt.trustpoint;
-          break;
-        }
-        if (!result || (receipt.trustpoint > result.trustpoint && node.serial > result.serial)) result = node;
-      } catch (e) {
-        console.warn(`Could not verify from peer ${node.from.host}:${node.from.port}: ${e}`);
-      }
-    }
-    if (!result) {
-      return null;
-    }
-
-    closestNodes.splice(closestNodes.indexOf(result.from), 1);
-    result.closestNodes = closestNodes;
-
-    return result;
-
-    function commit(reply: any, dht: Fabric) {
-      if (!signed && result && refresh) {
-        if (refresh(result)) {
-          signed = c.encode(m.zonePutRequest, {
-            serial: result.serial,
-            value: result.value,
-            signature: result.signature,
-            proof: result.proof
-          });
-        } else {
-          refresh = null;
-        }
-      }
-
-      return signed
-        ? dht.request({
-          token: reply.token,
-          target,
-          command: COMMANDS.ZONE_PUT,
-          value: signed,
-        }, reply.from)
-        : Promise.resolve(null);
-    }
-  }
-
-  async nostrGet(npub: string, kind: number, d : string = '', opts: any = {}) {
-    if (npub.length !== 64 || !npub.match(/^[a-f0-9]{64}$/)) throw new Error(`expected a hex encoded npub`)
-    const targetString = nostrTarget(npub, kind, d);
-    const target = this.veritas.sha256(b4a.from(targetString));
-    let refresh = opts.refresh || null;
-    let signed: Buffer | Uint8Array | null = null;
-    let result: any = null;
-    opts = {...opts, map: mapNostr, commit: refresh ? commit : null};
-
-    const userCreatedAt = opts.createdAt || 0;
-    const query = this.query({target, command: COMMANDS.NOSTR_GET, value: c.encode(c.uint, userCreatedAt)}, opts);
-    const latest = opts.latest !== false;
-    const closestNodes: Buffer[] = [];
-    const pubkey = b4a.from(npub, 'hex');
 
     for await (const node of query) {
       closestNodes.push(node.from);
       if (result && node.createdAt <= result.createdAt) continue;
       if (node.createdAt < userCreatedAt) continue;
-      try {
-        this.veritas.verifyNostr(target, node.value, pubkey, node.signature);
-        if (!latest) {
-          result = node;
-          break;
-        }
-        if (!result || (node.createdAt > result.createdAt)) result = node;
-      } catch (e) {
-        console.warn(`Could not verify from peer ${node.from.host}:${node.from.port}: ${e}`);
+      const targetInfo = verifyTarget(node.event, target);
+      if (!targetInfo) continue;
+      if (!this.anchor.verifySig(node.event)) continue;
+      if (targetInfo.space && !this.anchor.verifyAnchor(node.event, targetInfo)) continue;
+      if (!latest) {
+        result = node;
+        break;
       }
+      if (!result || (node.event.created_at > result.event.created_at)) result = node;
     }
     if (!result) {
       return null;
@@ -279,11 +173,7 @@ export class Fabric extends HyperDHT {
     function commit(reply: any, dht: Fabric) {
       if (!signed && result && refresh) {
         if (refresh(result)) {
-          signed = c.encode(m.nostrPutRequest, {
-            value: result.value,
-            publicKey: result.publicKey,
-            signature: result.signature,
-          });
+          signed = c.encode(m.compactEvent, result.event);
         } else {
           refresh = null;
         }
@@ -293,53 +183,58 @@ export class Fabric extends HyperDHT {
         ? dht.request({
           token: reply.token,
           target,
-          command: COMMANDS.NOSTR_PUT,
+          command: COMMANDS.EVENT_PUT,
           value: signed,
         }, reply.from)
         : Promise.resolve(null);
     }
   }
 
-  onnostrput(req: any) {
+  onEventPut(req: any) {
     if (!req.target || !req.token || !req.value) return;
-
-    const p = decode(m.nostrPutRequest, req.value);
+    const p: CompactEvent = decode(m.compactEvent, req.value);
     if (!p) return;
+    if (!isAcceptableEvent(p.kind)) return;
 
-    const {value, publicKey, signature} = p;
-    if (!value) return;
+    const targetInfo = verifyTarget(p, req.target);
+    if (!targetInfo) return;
+    if (!this.anchor.verifySig(p)) return;
 
-    if (req.target.length !== 32) return;
-    let evtCreatedAt : number;
-    try {
-      evtCreatedAt = this.veritas.verifyNostr(req.target, value, publicKey, signature);
-    } catch (e) {
-      console.error(e)
-      req.error(ERROR.EVENT_MALFORMED)
-      return;
-    }
-
+    const isAnchored = !!targetInfo.space;
     const k = b4a.toString(req.target, 'hex');
-    const local = this._nostr?.get(k);
-    if (local) {
-      const existing = c.decode(m.nostrRecord, local);
-      if (existing.createdAt > evtCreatedAt) {
+
+    const local = isAnchored ? this._spaces?.get(k) : this._pubkeys?.get(k);
+    let existing: any = local ? decode(isAnchored ? m.eventRecord : m.compactEvent, local) : undefined;
+
+    if (existing) {
+      if (existing.created_at > p.created_at) {
         req.error(ERROR.EVENT_TOO_OLD);
+        return;
+      }
+      const now = Math.floor(Date.now() / 1000);
+      const max = now + 30 * 24 * 60 * 60; // 30 days in future
+      if (p.created_at > max) {
+        req.error(ERROR.EVENT_TOO_NEW);
         return;
       }
     }
 
-    console.log(`nostrPut: storing ${req.target.toString('hex')}`);
-    this._nostr?.set(k, c.encode(m.nostrRecord, {
-      value,
-      signature,
-      publicKey,
-      createdAt: evtCreatedAt
-    }));
+    if (isAnchored) {
+      try {
+        const store = this.anchor.assertAnchored(p, targetInfo, existing);
+        this._spaces?.set(k, c.encode(m.eventRecord, store));
+        req.reply(null);
+      } catch (e) {
+        req.error(ERROR.EVENT_ANCHOR_REJECTED);
+      }
+      return;
+    }
+
+    this._pubkeys?.set(k, c.encode(m.compactEvent, p))
     req.reply(null);
   }
 
-  onnostrget(req: any) {
+  onEventGet(req: any) {
     if (!req.target || !req.value) return;
 
     let createdAt = 0;
@@ -350,7 +245,7 @@ export class Fabric extends HyperDHT {
     }
 
     const k = b4a.toString(req.target, 'hex');
-    const value = this._nostr?.get(k);
+    const value = this._spaces?.get(k) || this._pubkeys?.get(k);
 
     if (!value) {
       req.reply(null);
@@ -361,130 +256,15 @@ export class Fabric extends HyperDHT {
     req.reply(localCreatedAt < createdAt ? null : value);
   }
 
-  onzoneput(req: any) {
-    if (!req.target || !req.token || !req.value) return;
-
-    const p = decode(m.zonePutRequest, req.value);
-    if (!p) return;
-
-    const {serial, value, signature, proof} = p;
-    if (!value) return;
-
-    const msg = c.encode(m.zoneSignable, {serial, value});
-    let receipt: Receipt | null = null;
-    let publicKey : Uint8Array | undefined;
-    try {
-      // Validate the proof first.
-      receipt = this.veritas.verifyZone(req.target, msg, signature, proof);
-      publicKey = receipt.spaceout.getPublicKey();
-      if (!publicKey) throw new Error('Expected a public key');
-    } catch (e: any) {
-      console.error(e);
-      req.error(typeof e == 'string' && e.includes('NoMatchingAnchor') ?
-        ERROR.NO_MATCHING_TRUST_ANCHOR : ERROR.INVALID_SIGNATURE
-      );
-      return;
-    }
-
-    const k = b4a.toString(req.target, 'hex');
-    const local = this._zones?.get(k);
-    if (local) {
-      const existing = c.decode(m.zoneRecord, local);
-      const identical = existing.value && b4a.compare(value, existing.value) === 0;
-      const localTrustpoint = this.veritas.getTrustPoint(existing.root);
-
-      // Prevent reuse of a sequence when the value has changed.
-      if (existing.value && !identical && existing.serial === serial) {
-        req.error(ERROR.SEQ_REUSED);
-        return;
-      }
-      // New updates must have a higher sequence.
-      if (serial < existing.serial) {
-        req.error(ERROR.SEQ_TOO_LOW);
-        return;
-      }
-
-      const pubkey_changed = b4a.compare(publicKey , existing.publicKey) !== 0;
-      if (pubkey_changed) {
-        // We only require that the new proof is higher than the stored proof.
-        if (localTrustpoint && receipt.trustpoint <= localTrustpoint) {
-          req.error(ERROR.STALE_PROOF);
-          return;
-        }
-      } else {
-        // Pubkeys still the same, we prefer older but non-stale proofs
-        if (localTrustpoint && receipt.trustpoint !== localTrustpoint) {
-          // If the submitted proof is stale and older than the stored proof, reject it.
-          // Note: this still allows older proofs to take priority over recent ones as long
-          // as they're not stale.
-          if (this.veritas.isStale(receipt.trustpoint) && receipt.trustpoint < localTrustpoint) {
-            req.error(ERROR.STALE_PROOF);
-            return;
-          }
-          // If the stored proof is still valid (non-stale) and the new proof is more recent,
-          // we reject the new proof since the value (and pubkey) hasn't changed.
-          //
-          // This ensures:
-          // 1. Clients with older trust anchors can continue to validate.
-          // 2. Someone can't publish very recent proofs for spaces they don't own to block older clients.
-          if (!this.veritas.isStale(localTrustpoint) && receipt.trustpoint > localTrustpoint) {
-            req.error(ERROR.NON_STALE_ANCESTOR_EXISTS);
-            return;
-          }
-        }
-      }
-    }
-
-    console.log(`zonePut: storing ${req.target.toString('hex')}`);
-    this._zones?.set(k, c.encode(m.zoneRecord, {
-      serial,
-      value,
-      signature,
-      root: receipt.root,
-      publicKey,
-      proof
-    }));
-    req.reply(null);
-  }
-
-
-  onzoneget(req: any) {
-    if (!req.target || !req.value) return;
-
-    let serial = 0;
-    try {
-      serial = c.decode(c.uint, req.value);
-    } catch {
-      return;
-    }
-
-    const k = b4a.toString(req.target, 'hex');
-    const value = this._zones?.get(k);
-
-    if (!value) {
-      req.reply(null);
-      return;
-    }
-
-    const localSerial = c.decode(c.uint, value);
-    req.reply(localSerial < serial ? null : value);
-  }
-
   onrequest(req: any): boolean {
-    if (!this._zones) return super.onrequest(req);
+    if (!this._spaces || !this._pubkeys) return super.onrequest(req);
 
     switch (req.command) {
-    case COMMANDS.ZONE_PUT:
-      this.onzoneput(req);
+    case COMMANDS.EVENT_PUT:
+      this.onEventPut(req);
       return true;
-    case COMMANDS.ZONE_GET:
-      this.onzoneget(req);
-      return true;
-    case COMMANDS.NOSTR_PUT:
-      this.onnostrput(req);
-      return true;
-    case COMMANDS.NOSTR_GET:
-      this.onnostrget(req);
+    case COMMANDS.EVENT_GET:
+      this.onEventGet(req);
       return true;
     default:
       return super.onrequest(req);
@@ -493,7 +273,7 @@ export class Fabric extends HyperDHT {
 
   destroy(opts?: { force?: boolean }): Promise<void> {
     super.destroy(opts);
-    this.veritas.destroy()
+    this.anchor.destroy()
     return Promise.resolve()
   }
 }
@@ -506,40 +286,17 @@ function decode(enc: any, val: any) {
   }
 }
 
-function mapZone(node: any) {
+function mapEvent(node: any) : NodeResposne | null  {
   if (!node.value) return null;
 
   try {
-    const {serial, value, signature, proof} = c.decode(m.zoneRecord, node.value);
+    const event = c.decode(m.compactEvent, node.value);
 
     return {
       token: node.token,
       from: node.from,
       to: node.to,
-      serial,
-      value,
-      signature,
-      proof
-    };
-  } catch {
-    return null;
-  }
-}
-
-function mapNostr(node: any) {
-  if (!node.value) return null;
-
-  try {
-    const {createdAt, value, publicKey, signature} = c.decode(m.nostrRecord, node.value);
-
-    return {
-      token: node.token,
-      from: node.from,
-      to: node.to,
-      publicKey,
-      createdAt,
-      value,
-      signature,
+      event
     };
   } catch {
     return null;

--- a/messages.ts
+++ b/messages.ts
@@ -1,152 +1,118 @@
 import c from 'compact-encoding';
+import b4a from 'b4a';
+import {NostrEvent} from './utils';
 
-export interface ZoneSignable {
-  serial: number;
-  value: Uint8Array | null;
+export interface CompactEvent {
+  created_at: number;
+  kind: number;
+  pubkey: Uint8Array;
+  tags: string[][];
+  // Whether to base64 encode it or keep it as utf-8 string
+  // when converting it back to a canonical nostr event
+  binary_content: boolean,
+  content: Uint8Array,
+  sig: Uint8Array,
+  proof: Uint8Array
 }
 
-export interface ZonePutRequest {
-  serial: number;
-  value: Uint8Array | null;
-  signature: Uint8Array;
-  proof: Uint8Array |  null;
+export interface EventRecord {
+  event: CompactEvent,
+  root: Uint8Array
 }
 
-export interface ZoneRecord {
-  serial: number;
-  value: Uint8Array | null;
-  signature: Uint8Array;
-  root: Uint8Array;
-  publicKey: Uint8Array;
-  proof: Uint8Array | null;
+export interface TargetInfo {
+  target: Uint8Array,
+  space?: string,
+  d?: string,
 }
 
-export interface NostrPutRequest {
-  value: Uint8Array | null;
-  publicKey: Uint8Array;
-  signature: Uint8Array;
+export function toCompactEvent(evt: NostrEvent, binary_content: boolean) : Uint8Array {
+  if (!evt.sig) throw new Error('must be a signed event');
+
+  return c.encode(compactEvent, {
+    created_at: evt.created_at,
+    kind: evt.kind,
+    tags: evt.tags,
+    binary_content: binary_content,
+    content:  b4a.from(evt.content, binary_content ? 'base64' : 'utf-8'),
+    sig: b4a.from(evt.sig, 'hex'),
+    pubkey: b4a.from(evt.pubkey, 'hex'),
+    proof: evt.proof ? b4a.from(evt.proof, 'base64') : null,
+  });
 }
 
-export interface NostrRecord {
-  createdAt: number;
-  value: Uint8Array | null;
-  publicKey: Uint8Array;
-  signature: Uint8Array;
+export function signableCompactEvent(evt: CompactEvent) : Uint8Array {
+  return b4a.from(JSON.stringify([
+    0,
+    b4a.toString(evt.pubkey, 'hex'),
+    evt.created_at,
+    evt.kind,
+    evt.tags,
+    b4a.toString(evt.content || new Uint8Array(), evt.binary_content ? 'base64' : 'utf-8'),
+  ]), 'utf-8')
 }
 
-// ZoneSignable encoding/decoding structure
-export const zoneSignable = {
-  preencode(state: any, m: ZoneSignable): void {
-    c.uint.preencode(state, m.serial);
-    c.buffer.preencode(state, m.value);
+export function toEvent(evt: CompactEvent) : NostrEvent {
+  return {
+    pubkey: b4a.toString(evt.pubkey, 'hex'),
+    created_at: evt.created_at,
+    kind: evt.kind,
+    tags: evt.tags,
+    content: b4a.toString(evt.content || new Uint8Array(), evt.binary_content ? 'base64' : 'utf-8'),
+    sig: b4a.toString(evt.sig, 'hex'),
+    proof: evt.proof ? b4a.toString(evt.proof, 'base64') : undefined
+  }
+}
+
+
+export const compactEvent = {
+  preencode (state: any, m: CompactEvent): void {
+    c.uint.preencode(state, m.created_at)
+    c.uint.preencode(state, m.kind)
+    c.fixed32.preencode(state, m.pubkey)
+    c.array(c.array(c.utf8)).preencode(state, m.tags)
+    c.bool.preencode(state, m.binary_content)
+    c.buffer.preencode(state, m.content)
+    c.fixed64.preencode(state, m.sig)
+    c.buffer.preencode(state, m.proof)
   },
-  encode(state: any, m: ZoneSignable): void {
-    c.uint.encode(state, m.serial);
-    c.buffer.encode(state, m.value);
-  },
-  decode(state: any): ZoneSignable {
-    return {
-      serial: c.uint.decode(state),
-      value: c.buffer.decode(state),
-    };
-  },
-};
-
-// ZonePutRequest encoding/decoding structure
-export const zonePutRequest = {
-  preencode(state: any, m: ZonePutRequest): void {
-    c.uint.preencode(state, m.serial);
-    c.buffer.preencode(state, m.value);
-    c.fixed64.preencode(state, m.signature);
-    c.buffer.preencode(state, m.proof);
-  },
-  encode(state: any, m: ZonePutRequest): void {
-    c.uint.encode(state, m.serial);
-    c.buffer.encode(state, m.value);
-    c.fixed64.encode(state, m.signature);
+  encode (state: any, m: CompactEvent): void {
+    c.uint.encode(state, m.created_at)
+    c.uint.encode(state, m.kind)
+    c.fixed32.encode(state, m.pubkey)
+    c.array(c.array(c.utf8)).encode(state, m.tags)
+    c.bool.encode(state, m.binary_content)
+    c.buffer.encode(state, m.content)
+    c.fixed64.encode(state, m.sig)
     c.buffer.encode(state, m.proof)
   },
-  decode(state: any): ZonePutRequest {
+  decode (state: any): CompactEvent {
     return {
-      serial: c.uint.decode(state),
-      value: c.buffer.decode(state),
-      signature: c.fixed64.decode(state),
-      proof: c.buffer.decode(state),
-    };
-  },
-};
+      created_at: c.uint.decode(state),
+      kind: c.uint.decode(state),
+      pubkey: c.fixed32.decode(state),
+      tags: c.array(c.array(c.utf8)).decode(state),
+      binary_content: c.bool.decode(state),
+      content: c.buffer.decode(state) || new Uint8Array,
+      sig: c.fixed64.decode(state),
+      proof: c.buffer.decode(state) || new Uint8Array
+    }
+  }
+}
 
-// ZoneRecord encoding/decoding structure
-export const zoneRecord = {
-  preencode(state: any, m: ZoneRecord): void {
-    c.uint.preencode(state, m.serial);
-    c.buffer.preencode(state, m.value);
-    c.fixed64.preencode(state, m.signature);
-    c.fixed32.preencode(state, m.root);
-    c.fixed32.preencode(state, m.publicKey);
-    c.buffer.preencode(state, m.proof);
+export const eventRecord = {
+  preencode (state: any, m: EventRecord): void {
+    compactEvent.preencode(state, m.event)
+    c.fixed32.preencode(state, m.root)
   },
-  encode(state: any, m: ZoneRecord): void {
-    c.uint.encode(state, m.serial);
-    c.buffer.encode(state, m.value);
-    c.fixed64.encode(state, m.signature);
-    c.fixed32.encode(state, m.root);
-    c.fixed32.encode(state, m.publicKey);
-    c.buffer.encode(state, m.proof);
+  encode (state: any, m: EventRecord): void {
+    compactEvent.encode(state, m.event)
+    c.fixed32.encode(state, m.root)
   },
-  decode(state: any): ZoneRecord {
+  decode (state: any): EventRecord {
     return {
-      serial: c.uint.decode(state),
-      value: c.buffer.decode(state),
-      signature: c.fixed64.decode(state),
-      root: c.fixed32.decode(state),
-      publicKey: c.fixed32.decode(state),
-      proof: c.buffer.decode(state),
-    };
-  },
-};
-
-// NostrPutRequest encoding/decoding structure
-export const nostrPutRequest = {
-  preencode(state: any, m: NostrPutRequest): void {
-    c.buffer.preencode(state, m.value);
-    c.fixed32.preencode(state, m.publicKey);
-    c.fixed64.preencode(state, m.signature);
-  },
-  encode(state: any, m: NostrPutRequest): void {
-    c.buffer.encode(state, m.value);
-    c.fixed32.encode(state, m.publicKey);
-    c.fixed64.encode(state, m.signature);
-  },
-  decode(state: any): NostrPutRequest {
-    return {
-      value: c.buffer.decode(state),
-      publicKey: c.fixed32.decode(state),
-      signature: c.fixed64.decode(state),
-    };
-  },
-};
-
-// NostrRecord encoding/decoding structure
-export const nostrRecord = {
-  preencode(state: any, m: NostrRecord): void {
-    c.uint.preencode(state, m.createdAt);
-    c.buffer.preencode(state, m.value);
-    c.fixed32.preencode(state, m.publicKey);
-    c.fixed64.preencode(state, m.signature);
-  },
-  encode(state: any, m: NostrRecord): void {
-    c.uint.encode(state, m.createdAt);
-    c.buffer.encode(state, m.value);
-    c.fixed32.encode(state, m.publicKey);
-    c.fixed64.encode(state, m.signature);
-  },
-  decode(state: any): NostrRecord {
-    return {
-      createdAt: c.uint.decode(state),
-      value: c.buffer.decode(state),
-      publicKey: c.fixed32.decode(state),
-      signature: c.fixed64.decode(state),
-    };
-  },
+      event: compactEvent.decode(state),
+      root: c.fixed32.decode(state)
+    }
+  }
 };

--- a/messages.ts
+++ b/messages.ts
@@ -1,19 +1,19 @@
 import c from 'compact-encoding';
 
 export interface ZoneSignable {
-  seq: number;
+  serial: number;
   value: Uint8Array | null;
 }
 
 export interface ZonePutRequest {
-  seq: number;
+  serial: number;
   value: Uint8Array | null;
   signature: Uint8Array;
   proof: Uint8Array |  null;
 }
 
 export interface ZoneRecord {
-  seq: number;
+  serial: number;
   value: Uint8Array | null;
   signature: Uint8Array;
   root: Uint8Array;
@@ -37,16 +37,16 @@ export interface NostrRecord {
 // ZoneSignable encoding/decoding structure
 export const zoneSignable = {
   preencode(state: any, m: ZoneSignable): void {
-    c.uint.preencode(state, m.seq);
+    c.uint.preencode(state, m.serial);
     c.buffer.preencode(state, m.value);
   },
   encode(state: any, m: ZoneSignable): void {
-    c.uint.encode(state, m.seq);
+    c.uint.encode(state, m.serial);
     c.buffer.encode(state, m.value);
   },
   decode(state: any): ZoneSignable {
     return {
-      seq: c.uint.decode(state),
+      serial: c.uint.decode(state),
       value: c.buffer.decode(state),
     };
   },
@@ -55,20 +55,20 @@ export const zoneSignable = {
 // ZonePutRequest encoding/decoding structure
 export const zonePutRequest = {
   preencode(state: any, m: ZonePutRequest): void {
-    c.uint.preencode(state, m.seq);
+    c.uint.preencode(state, m.serial);
     c.buffer.preencode(state, m.value);
     c.fixed64.preencode(state, m.signature);
     c.buffer.preencode(state, m.proof);
   },
   encode(state: any, m: ZonePutRequest): void {
-    c.uint.encode(state, m.seq);
+    c.uint.encode(state, m.serial);
     c.buffer.encode(state, m.value);
     c.fixed64.encode(state, m.signature);
     c.buffer.encode(state, m.proof)
   },
   decode(state: any): ZonePutRequest {
     return {
-      seq: c.uint.decode(state),
+      serial: c.uint.decode(state),
       value: c.buffer.decode(state),
       signature: c.fixed64.decode(state),
       proof: c.buffer.decode(state),
@@ -79,7 +79,7 @@ export const zonePutRequest = {
 // ZoneRecord encoding/decoding structure
 export const zoneRecord = {
   preencode(state: any, m: ZoneRecord): void {
-    c.uint.preencode(state, m.seq);
+    c.uint.preencode(state, m.serial);
     c.buffer.preencode(state, m.value);
     c.fixed64.preencode(state, m.signature);
     c.fixed32.preencode(state, m.root);
@@ -87,7 +87,7 @@ export const zoneRecord = {
     c.buffer.preencode(state, m.proof);
   },
   encode(state: any, m: ZoneRecord): void {
-    c.uint.encode(state, m.seq);
+    c.uint.encode(state, m.serial);
     c.buffer.encode(state, m.value);
     c.fixed64.encode(state, m.signature);
     c.fixed32.encode(state, m.root);
@@ -96,7 +96,7 @@ export const zoneRecord = {
   },
   decode(state: any): ZoneRecord {
     return {
-      seq: c.uint.decode(state),
+      serial: c.uint.decode(state),
       value: c.buffer.decode(state),
       signature: c.fixed64.decode(state),
       root: c.fixed32.decode(state),

--- a/messages.ts
+++ b/messages.ts
@@ -12,13 +12,26 @@ export interface ZonePutRequest {
   proof: Uint8Array |  null;
 }
 
-export interface ZoneGetResponse {
+export interface ZoneRecord {
   seq: number;
   value: Uint8Array | null;
   signature: Uint8Array;
   root: Uint8Array;
   publicKey: Uint8Array;
   proof: Uint8Array | null;
+}
+
+export interface NostrPutRequest {
+  value: Uint8Array | null;
+  publicKey: Uint8Array;
+  signature: Uint8Array;
+}
+
+export interface NostrRecord {
+  createdAt: number;
+  value: Uint8Array | null;
+  publicKey: Uint8Array;
+  signature: Uint8Array;
 }
 
 // ZoneSignable encoding/decoding structure
@@ -63,9 +76,9 @@ export const zonePutRequest = {
   },
 };
 
-// ZoneGetResponse encoding/decoding structure
-export const zoneGetResponse = {
-  preencode(state: any, m: ZoneGetResponse): void {
+// ZoneRecord encoding/decoding structure
+export const zoneRecord = {
+  preencode(state: any, m: ZoneRecord): void {
     c.uint.preencode(state, m.seq);
     c.buffer.preencode(state, m.value);
     c.fixed64.preencode(state, m.signature);
@@ -73,7 +86,7 @@ export const zoneGetResponse = {
     c.fixed32.preencode(state, m.publicKey);
     c.buffer.preencode(state, m.proof);
   },
-  encode(state: any, m: ZoneGetResponse): void {
+  encode(state: any, m: ZoneRecord): void {
     c.uint.encode(state, m.seq);
     c.buffer.encode(state, m.value);
     c.fixed64.encode(state, m.signature);
@@ -81,7 +94,7 @@ export const zoneGetResponse = {
     c.fixed32.encode(state, m.publicKey);
     c.buffer.encode(state, m.proof);
   },
-  decode(state: any): ZoneGetResponse {
+  decode(state: any): ZoneRecord {
     return {
       seq: c.uint.decode(state),
       value: c.buffer.decode(state),
@@ -89,6 +102,51 @@ export const zoneGetResponse = {
       root: c.fixed32.decode(state),
       publicKey: c.fixed32.decode(state),
       proof: c.buffer.decode(state),
+    };
+  },
+};
+
+// NostrPutRequest encoding/decoding structure
+export const nostrPutRequest = {
+  preencode(state: any, m: NostrPutRequest): void {
+    c.buffer.preencode(state, m.value);
+    c.fixed32.preencode(state, m.publicKey);
+    c.fixed64.preencode(state, m.signature);
+  },
+  encode(state: any, m: NostrPutRequest): void {
+    c.buffer.encode(state, m.value);
+    c.fixed32.encode(state, m.publicKey);
+    c.fixed64.encode(state, m.signature);
+  },
+  decode(state: any): NostrPutRequest {
+    return {
+      value: c.buffer.decode(state),
+      publicKey: c.fixed32.decode(state),
+      signature: c.fixed64.decode(state),
+    };
+  },
+};
+
+// NostrRecord encoding/decoding structure
+export const nostrRecord = {
+  preencode(state: any, m: NostrRecord): void {
+    c.uint.preencode(state, m.createdAt);
+    c.buffer.preencode(state, m.value);
+    c.fixed32.preencode(state, m.publicKey);
+    c.fixed64.preencode(state, m.signature);
+  },
+  encode(state: any, m: NostrRecord): void {
+    c.uint.encode(state, m.createdAt);
+    c.buffer.encode(state, m.value);
+    c.fixed32.encode(state, m.publicKey);
+    c.fixed64.encode(state, m.signature);
+  },
+  decode(state: any): NostrRecord {
+    return {
+      createdAt: c.uint.decode(state),
+      value: c.buffer.decode(state),
+      publicKey: c.fixed32.decode(state),
+      signature: c.fixed64.decode(state),
     };
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spacesprotocol/veritas": "^0.0.1",
+        "@spacesprotocol/veritas": "^0.0.2",
         "b4a": "^1.3.1",
         "commander": "^12.1.0",
         "compact-encoding": "^2.4.1",
@@ -353,9 +353,9 @@
       }
     },
     "node_modules/@spacesprotocol/veritas": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@spacesprotocol/veritas/-/veritas-0.0.1.tgz",
-      "integrity": "sha512-j0nElHDPFmUvUUKvHaM0AMRgWm0BTbLbwgLjsWEskibnlHQ/S1ppmzc09bEeoQrXiWA1cUoBCETIj0LUjq9ADA=="
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@spacesprotocol/veritas/-/veritas-0.0.2.tgz",
+      "integrity": "sha512-n7pwnPLTEzSZ2+BMOI+IyCy8dwpN35udpShHXtq1xj7harsN6OitlnWBek4CQgs3QPDo66H9LnWHWMuEokvPcQ=="
     },
     "node_modules/@types/b4a": {
       "version": "1.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spacesprotocol/veritas": "^0.0.2",
+        "@spacesprotocol/veritas": "^0.0.6",
         "b4a": "^1.3.1",
         "commander": "^12.1.0",
         "compact-encoding": "^2.4.1",
@@ -353,9 +353,9 @@
       }
     },
     "node_modules/@spacesprotocol/veritas": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@spacesprotocol/veritas/-/veritas-0.0.2.tgz",
-      "integrity": "sha512-n7pwnPLTEzSZ2+BMOI+IyCy8dwpN35udpShHXtq1xj7harsN6OitlnWBek4CQgs3QPDo66H9LnWHWMuEokvPcQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@spacesprotocol/veritas/-/veritas-0.0.6.tgz",
+      "integrity": "sha512-i5nB2rdAYsuiG07Ye2RJSIV6IW9FMNRLZ/dPAImJ8iWlUYHRXzFURhdfWbFcbeKXTBaIzP5T3fUpmY7d+O5DXQ=="
     },
     "node_modules/@types/b4a": {
       "version": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "beam": "./dist/bin/beam.js"
   },
   "dependencies": {
-    "@spacesprotocol/veritas": "^0.0.2",
+    "@spacesprotocol/veritas": "^0.0.6",
     "b4a": "^1.3.1",
     "commander": "^12.1.0",
     "compact-encoding": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "beam": "./dist/bin/beam.js"
   },
   "dependencies": {
-    "@spacesprotocol/veritas": "^0.0.1",
+    "@spacesprotocol/veritas": "^0.0.2",
     "b4a": "^1.3.1",
     "commander": "^12.1.0",
     "compact-encoding": "^2.4.1",

--- a/test/helpers/anchors.ts
+++ b/test/helpers/anchors.ts
@@ -1,5 +1,271 @@
 export const staticAnchors = [
   {
+    root: '7449e00c85687afaefd35d471eea8d947c72099b9043cf98746d7537e347fa5a',
+    block: {
+      hash: '0000000000000000000233c51bbc6652f74e608ee3e90199dfd49a6cb02cfa5b',
+      height: 886104
+    }
+  },
+  {
+    root: '4c5dd24cc916921932eaa772ebcc5cbb110a4ce03169774c6390e1aef4cb4c81',
+    block: {
+      hash: '000000000000000000016893014e39b1005be20825e6f1b0b0f133a03f3261a6',
+      height: 886068
+    }
+  },
+  {
+    root: '9ccc6c8debbb143169b712f6ac1f066ef852ea5a3c1b7ffd5f469619964f5f17',
+    block: {
+      hash: '00000000000000000001ec0059b2d61a15cdc211301d4e6ecce20fdaf9a7180c',
+      height: 886032
+    }
+  },
+  {
+    root: '84d2bdea5ad42ef8a560ba0e43d7533615fbbc319c20b4e8e72566eb3e5fe101',
+    block: {
+      hash: '0000000000000000000016ee27fd521a3dbf0bf1607e9252ca38abe0e8854bde',
+      height: 885996
+    }
+  },
+  {
+    root: '84d2bdea5ad42ef8a560ba0e43d7533615fbbc319c20b4e8e72566eb3e5fe101',
+    block: {
+      hash: '00000000000000000000b23aab0a5056334daf3fe8c1e93a1500996bb7e23050',
+      height: 885960
+    }
+  },
+  {
+    root: '84d2bdea5ad42ef8a560ba0e43d7533615fbbc319c20b4e8e72566eb3e5fe101',
+    block: {
+      hash: '00000000000000000000ecbbc01673fa1d1519d52a43db35d2dab3db3cfc9237',
+      height: 885924
+    }
+  },
+  {
+    root: 'db8ef33084f2fe7a1a229b7b717d187d1e5a226adf90b74cba09a500106d2cf4',
+    block: {
+      hash: '000000000000000000017feb1126952b9b86a0386d3db554e501b674849d77e5',
+      height: 885888
+    }
+  },
+  {
+    root: '37db4f011dc8fcb37866ffb0aa5f2ecb7cbf3d04a0c576fcf90f1d8623c1d511',
+    block: {
+      hash: '00000000000000000001d352b0ebf62ef96395103d5a225bdcc090a98fbc68a2',
+      height: 885852
+    }
+  },
+  {
+    root: 'fbbbf6953f0abde9f5d1c0a22241789e3f10b4b8d3373adc2a5adc57ada72f5c',
+    block: {
+      hash: '00000000000000000001e4bdf8c25bc654bfaeb43ad987ea3a8e42f0d18a8dd9',
+      height: 885816
+    }
+  },
+  {
+    root: 'fbbbf6953f0abde9f5d1c0a22241789e3f10b4b8d3373adc2a5adc57ada72f5c',
+    block: {
+      hash: '00000000000000000000c6158bf1f08695f371b36f90d15d463c5371bbd34ca7',
+      height: 885780
+    }
+  },
+  {
+    root: '49c024e0e8c12410bc055465efb0433e5277b898a13bdbbbc74824d4c7259cf0',
+    block: {
+      hash: '00000000000000000000fa606cf45c897218b42d06faa7e0e01d36dacdf51a7e',
+      height: 885744
+    }
+  },
+  {
+    root: '035f51b417bf1926c7929e3b90fc303525f1dc1686c1a9d79f60a21408f3b1c0',
+    block: {
+      hash: '00000000000000000002236b8f4527f265212c3da23e5efe542cdca359a5cb09',
+      height: 885708
+    }
+  },
+  {
+    root: '9520a43fe14a00959aeb64b52bf2fce11853f943ab3907f7a77e3fb67e34548d',
+    block: {
+      hash: '000000000000000000014433da143480bd8b683a8020886bacabca8b63bf4bec',
+      height: 885672
+    }
+  },
+  {
+    root: '9520a43fe14a00959aeb64b52bf2fce11853f943ab3907f7a77e3fb67e34548d',
+    block: {
+      hash: '00000000000000000002582c5348a248df6a1a3159e9f7414399b8716f23179e',
+      height: 885636
+    }
+  },
+  {
+    root: '0c40c801055687479ad0275d182d9d3e08b2b281bc6036fb2dc19a77d4e6bc24',
+    block: {
+      hash: '000000000000000000012b231f3bc9c48966d8023ada2434614b4d8c4c0c5ead',
+      height: 885600
+    }
+  },
+  {
+    root: 'cf4dbb2f1a01933f3e30697de984f1748412c945f1a2f3f42db73759362f296a',
+    block: {
+      hash: '000000000000000000017a80dfaa247a1fd99711e31bd9ea5447e03c59744837',
+      height: 885564
+    }
+  },
+  {
+    root: '14c42918a42de23c8f1d21b18fae5bd90635bb91ee0dedf9cb32d90a84480dfa',
+    block: {
+      hash: '00000000000000000002102a388c2c70c2a48a0686fbe4212a4cb52130a471f8',
+      height: 885528
+    }
+  },
+  {
+    root: '14c42918a42de23c8f1d21b18fae5bd90635bb91ee0dedf9cb32d90a84480dfa',
+    block: {
+      hash: '000000000000000000010c1f43c999df6703cfa838d6853864ecf69643ab6d3e',
+      height: 885492
+    }
+  },
+  {
+    root: 'fe14096ce037cbc6fca958f7bbd027755c47692ecce692506d912ef169723456',
+    block: {
+      hash: '0000000000000000000066d2bec303cfe8b3ed4be3ca7a05e6417da2a7e52cf7',
+      height: 885456
+    }
+  },
+  {
+    root: '81a9da02e19550ab0fa8c6534838dba8180e8b3531254a64238e0a883cd7618b',
+    block: {
+      hash: '00000000000000000001f2bf1685d0522dce57fb588a0cc3bff281f623dc0331',
+      height: 885420
+    }
+  },
+  {
+    root: 'f811419903f9e27935dfd7938b85c0fa7d1ff36205f8a00165e432a8a9b975bb',
+    block: {
+      hash: '000000000000000000021525cd41d1de39c5e54e99f18fbd921a244f1efa6af6',
+      height: 885384
+    }
+  },
+  {
+    root: 'f811419903f9e27935dfd7938b85c0fa7d1ff36205f8a00165e432a8a9b975bb',
+    block: {
+      hash: '000000000000000000020ca1154a68e322cedcc2bc5b3c4aec82fd88c1a44c0a',
+      height: 885348
+    }
+  },
+  {
+    root: 'deaf265a4b1c79ad814fde70ef8dc6f33885b30c6fba5cdd8d9838807988f830',
+    block: {
+      hash: '0000000000000000000094f379b6a916a70c588e2243d155e8f3cb2e93706037',
+      height: 885312
+    }
+  },
+  {
+    root: 'd363c53e0565a4d64c1fe91159882c6c93033bf21b206ca344c6ae527f58f5be',
+    block: {
+      hash: '000000000000000000008ee92bc1a3e0fe09f472f5f36ef7017a12aed1fb9196',
+      height: 885276
+    }
+  },
+  {
+    root: 'e7f990eb24524a99602a97a4ba7d23d83d5302e112c333c5988e517362a66b2a',
+    block: {
+      hash: '000000000000000000024274ce349324a7d572440faab1d85a8619ce7b623b94',
+      height: 885240
+    }
+  },
+  {
+    root: 'a1c9d6ce0b6d22c26611dbc59433892261ded3cb61a4454bc6e8608209e70f9a',
+    block: {
+      hash: '00000000000000000000b8f53fbac44d7877f710c5a009cc85621520df165def',
+      height: 885204
+    }
+  },
+  {
+    root: '3ac8af6ff9c68817f6d0463351f4b2f64168070edda7eda4967900fbb85b175d',
+    block: {
+      hash: '00000000000000000002077dd944064c64becab33200716386eb5ec1e705bd0d',
+      height: 885168
+    }
+  },
+  {
+    root: 'fbaa378fb0f387e358969237639340651cb3b98357bc1b123e645e022febb543',
+    block: {
+      hash: '000000000000000000018ef4021a1f32658823846a9539e5553701ac9e976298',
+      height: 885132
+    }
+  },
+  {
+    root: 'ea114a4277097b535b47525dd6c512c4608c2de9a95847963d63d5dd8638e360',
+    block: {
+      hash: '00000000000000000000c7e8c4171a076f8de232028d9e0ff7cabcc6120749b6',
+      height: 885096
+    }
+  },
+  {
+    root: 'c9395f0256c5f665f30f191af459836f92073901f609d1dc6db0bc8787d82dbf',
+    block: {
+      hash: '00000000000000000001491cc9a1da165e4d2f1b248cbc0ae024b9ad8f8e9a07',
+      height: 885060
+    }
+  },
+  {
+    root: '10703fb6069e577518c5268d98de6ac31a4916837f268d99df07c83383d38f6c',
+    block: {
+      hash: '000000000000000000018891e11ee4fcb066571efa5238fe0f3586766b3bc141',
+      height: 885024
+    }
+  },
+  {
+    root: '98704576a6b742eb99230c34c7020380c5a3d828bef8d24110db2a0a8300cbb4',
+    block: {
+      hash: '00000000000000000000786cf4842bfa85903df2d415d7c5e07fe5300422b808',
+      height: 884988
+    }
+  },
+  {
+    root: '5cde8d63bb935514d54a6ba471e7e839ea4cf9c3d1014dc78db75fff15de634b',
+    block: {
+      hash: '000000000000000000014da760eda38cd19b1001e071d3b2569a0c8b5cf61a9c',
+      height: 884952
+    }
+  },
+  {
+    root: '4ee9b75d005ba6f7248ae99106cb9eb30b43915b699e0ebade954111f9e899c9',
+    block: {
+      hash: '00000000000000000000563eb1765c2b52bf778741b407ce6034a9604e6d55ed',
+      height: 884916
+    }
+  },
+  {
+    root: '552e845026b894c845a632d8f7c6365b5d47288c85b5643007ccead12f132248',
+    block: {
+      hash: '000000000000000000009e394aebf0ee278fcf6c0c67a6a93b6a6873039a56bd',
+      height: 884880
+    }
+  },
+  {
+    root: 'bb375a32fc1ee6112cf163c2197f0c2edf24f8b7ee407f2127b11a5a09f9329f',
+    block: {
+      hash: '0000000000000000000097d90e2de97b6faa94914ae545aed09551038d8b2cfa',
+      height: 884844
+    }
+  },
+  {
+    root: '4b1d4ac53505f5649df31fbac8c7bd987830774509a3cffe2a1adcefa3d515d2',
+    block: {
+      hash: '00000000000000000000b5a804d4ef39a7d727f18b685cdc530c81cc7d2e14c1',
+      height: 884808
+    }
+  },
+  {
+    root: 'd80370c373c27e3a89486cb7afde36e9911d987c4f703d58d1e30993149c2f98',
+    block: {
+      hash: '000000000000000000014bc888677c3382e28d59861234c84cdaf232a1385364',
+      height: 884772
+    }
+  },
+  {
     root: 'b5be872a859411e754490d7573c7597fddae7e272166d4c4edf9c466b5ce258f',
     block: {
       hash: '00000000000000000000248690f6ad997277288b2df7682495ba5ed9d9b12b7a',
@@ -574,249 +840,10 @@ export const staticAnchors = [
     }
   },
   {
-    root: '27cd54c48c4b08c3e4a32e4448435596405c9f1ca508e0c0c2c9b57d4654e1da',
+    root: '5328e8a1f6b0b4d3f89b0f41ed382cbf43fa5e980cef5420538fa2695225a15f',
     block: {
-      hash: '000000000000000000001600ba3162e60d265e9b68b8db34c1e8011c58ea367d',
-      height: 881784
-    }
-  },
-  {
-    root: 'e8e8c96bc33fdc2361bdc5c0cf295940e2cf0a495b761d99cfa076761c42fcfa',
-    block: {
-      hash: '000000000000000000011898fefbd573f48b90d24e0930f7aa72625ed4a96f23',
-      height: 881748
-    }
-  },
-  {
-    root: '07033be95007008ca13d058e58ff26fcb472f69ddb0976c942125f9627b2c876',
-    block: {
-      hash: '00000000000000000000b3f88996d913cf430b6c1b96c2ee2473106f611dafb3',
-      height: 881712
-    }
-  },
-  {
-    root: 'af7f56ab711b1e32d17496e40d4fea1d8e8b374cf95d57f315a70a6fc32ae045',
-    block: {
-      hash: '000000000000000000022247ce3898fc9e10be0161cde5f369293d7a916ca8b3',
-      height: 881676
-    }
-  },
-  {
-    root: 'de24406f7a853bba092d687aa712604290f877c44a1de27d81026925cc6b9030',
-    block: {
-      hash: '000000000000000000021ce45cd129bbaf9caa27edfeca4b030ac2422da9a0e6',
-      height: 881640
-    }
-  },
-  {
-    root: '9467ab0f60a31269911de291b7373eeedc0e7a401f0fff4ca49fa70c7317aa01',
-    block: {
-      hash: '00000000000000000001b897d4667c18aea035322512404fc9d75595c75377e1',
-      height: 881604
-    }
-  },
-  {
-    root: 'f75975eae72cf3a341cb1820ab1b3f9a8a3c01025904ecf9298f78356d0cb25a',
-    block: {
-      hash: '00000000000000000001bd88789d506275df37f3fcf24473040e075ec304ed02',
-      height: 881568
-    }
-  },
-  {
-    root: '68b075a509ad5ae4874b32866343b25cc99e5403c6307241a60992ebdd9e3963',
-    block: {
-      hash: '00000000000000000001300f56ab1d2f75e88c9a14317b667e5901ca434acd36',
-      height: 881532
-    }
-  },
-  {
-    root: '8781cdbfe81ebc4503d6d768d1c205d48f293517e09220f5d89c7a5d8de0e138',
-    block: {
-      hash: '00000000000000000001f79a8009621c497046412e61908bb6503fb052d2ba56',
-      height: 881496
-    }
-  },
-  {
-    root: '973cdbdbbe1f117570677c4c310120520919e4c819ef49707dbdebb5e77f990c',
-    block: {
-      hash: '00000000000000000002244e97a52e20087be43f38e7a25fa85acaaac0792ea8',
-      height: 881460
-    }
-  },
-  {
-    root: 'c6ddbf029007740053d418f422d0ab0ced272b33cef6e68e4d283c2124a191e5',
-    block: {
-      hash: '000000000000000000017b20a1eda0f8cec8a7fe17744dacd9fac5961cd70b72',
-      height: 881424
-    }
-  },
-  {
-    root: '5bb6bd079e09cf5f61f4bce5ea0429ea4be5ba21b906da6a16b3579e62bf9397',
-    block: {
-      hash: '00000000000000000001bbfc958eccdb26b414a6fd97188fbd0b65734eb9f4b4',
-      height: 881388
-    }
-  },
-  {
-    root: 'db7b0c3ee5570a84d73926f91f0d8d543da374cec082483b3f774fdb567adde0',
-    block: {
-      hash: '000000000000000000002437134508f6de903499641702f576c5c835ea2ccd6e',
-      height: 881352
-    }
-  },
-  {
-    root: '2233a3e2f0c1dbf3746250affd0dda9d3ee533ea48cdaf7e51fa63eb448a4026',
-    block: {
-      hash: '00000000000000000000d51378ae7efa5652bfe59238a5299238ad10a106efad',
-      height: 881316
-    }
-  },
-  {
-    root: '0e9e3e1e604b6c9e6104ad54e318f9db4431ca1dce597c7db376131d8a1564a8',
-    block: {
-      hash: '00000000000000000000b6097f22ed9c6ed881a876025f582220252b8c56cdd1',
-      height: 881280
-    }
-  },
-  {
-    root: '1000b6ccda30b909989daf6b8ad0cdd454566df776d567e27f8bb866710ff473',
-    block: {
-      hash: '0000000000000000000203367d31d027c1bdec424385971f6134eda046634ecc',
-      height: 881244
-    }
-  },
-  {
-    root: '80ed2268a1bc7ead3b99ebace4147df35d57428e223dd467f3112ca64b8fa11b',
-    block: {
-      hash: '00000000000000000001a59273398c45d3c16d1f82aab52bc4fb45b42814e5e0',
-      height: 881208
-    }
-  },
-  {
-    root: '22041637ab2e4afa01ab011653b1f39640773ff93ca3d9f9ebd8360b312bdd20',
-    block: {
-      hash: '00000000000000000001755458b510d16dbbfe9acbfd267c54d4983847db6a35',
-      height: 881172
-    }
-  },
-  {
-    root: '3998f191bbdd584b5190a233306d1b32226e4ef20a30c25e99c90d061560210f',
-    block: {
-      hash: '000000000000000000007b5f914aaa218fa9feb234322cd3cbd8b0c0e67d535d',
-      height: 881136
-    }
-  },
-  {
-    root: 'ed50b025cc0a10c168f89036eddc578436e223f61c689a83f6d0d7e0d15155ed',
-    block: {
-      hash: '000000000000000000001b7d47676281b70e9c7e05e73c9cadb7afaaf17d6ef5',
-      height: 881100
-    }
-  },
-  {
-    root: 'aa7b489df45f4c8a46fb6af1c9e215dfec2c94444042886a3ea7618ef82d418c',
-    block: {
-      hash: '00000000000000000002718db17871a743fd5b59d9e1eef939690d481947e396',
-      height: 881064
-    }
-  },
-  {
-    root: '123e194f5d17c8eee963eda124820d4016fd0942a2a5302e0e0d2626f504af7e',
-    block: {
-      hash: '00000000000000000001da7042b9329d532b3cfe882ac9e11c565b53fce5d26e',
-      height: 881028
-    }
-  },
-  {
-    root: 'c9e3f237debe01f1326f00897f39fbfa8e66fae8c02501cdb502d3b0e71f2d86',
-    block: {
-      hash: '00000000000000000002472ac2ebac866c74e35c870cd6f8193bd98296361883',
-      height: 880992
-    }
-  },
-  {
-    root: '30ede67ebacceb164e9a22b2f65cc734b23b16312394176bc627d8e075280d69',
-    block: {
-      hash: '000000000000000000017b8c084e8d6c879ca5b832e76eab14c10fa6d457f229',
-      height: 880956
-    }
-  },
-  {
-    root: '11e793e65dee4cc5d0e4930d73dd6c26083fce59ebd4220c50378e44173a2622',
-    block: {
-      hash: '0000000000000000000086ca2db99e3a1698830f72091bb5c355415ee009d03f',
-      height: 880920
-    }
-  },
-  {
-    root: '1fa30ebfd76d3e8a473f6ee84c68d9619acc16dafc2133e4702113b7ef0af4a6',
-    block: {
-      hash: '00000000000000000001e01fb713e56a2761cdf34ae819b3005b19137fbf5964',
-      height: 880884
-    }
-  },
-  {
-    root: '5c9ff7d202f1f6498719b5f53865f7c47a34a848127590ba353aea7a7f1c52c2',
-    block: {
-      hash: '000000000000000000021f8423f55093eb4e5bfc357013d4c191c6f776717c5e',
-      height: 880848
-    }
-  },
-  {
-    root: '12de6d90515302d465bb3886574351b3d730998e9fbc3b10ac19e2467b2908ec',
-    block: {
-      hash: '0000000000000000000263d1745e4b14aeb77643aefa5a4d3b10d299d0544a2d',
-      height: 880776
-    }
-  },
-  {
-    root: 'e4076488dfa64974b4b59e263e79995a183d8ace42cfd65bd3a12065c25d5b2e',
-    block: {
-      hash: '00000000000000000001caa6dd86d851374a8fbf7e314d8ffed3848e4a1b2afa',
-      height: 880740
-    }
-  },
-  /* not an actual anchor */
-  {
-    root: 'e4076488dfa64974b4b59e263e79995a183d8ace42cfd65bd3a12065c25d5b2e',
-    block: {
-      hash: '00000000000000000001caa6dd86d851374a8fbf7e314d8ffed3848e4a1b2afa',
-      height: 880720
-    }
-  },
-  {
-    root: 'ee6bc6e95bf8d28de119c7973106fdb8a78057eab21238a25d0140f53c49a9ec',
-    block: {
-      hash: '0000000000000000000005e681ab128ae345ee51c8b34d9e90c13609be4ea42f',
-      height: 880704
-    }
-  },
-  {
-    root: '0ed8e48ac402cb6d280467fd42301e7b2818adc3f412b4066d2bde8d95495575',
-    block: {
-      hash: '0000000000000000000259dbb6d2fe81e1aed0b529a1a281bc4e4d35e770f6a2',
-      height: 880668
-    }
-  },
-  {
-    root: '83c6f24dd00af87a8defd784b9c1e49a4cf2df2f356c834a2046c3832a1851d2',
-    block: {
-      hash: '000000000000000000026f3872cb80cf5e94b5f657fbec2168f08c86c18f465f',
-      height: 880632
-    }
-  },
-  {
-    root: 'f8457df66819d045b806684e3137d95fa191680e0f46e34ecd434120630f6bf5',
-    block: {
-      hash: '00000000000000000000a3d728a735c8b6f5e57738e25ab465188e745c947abc',
-      height: 880596
-    }
-  },
-  {
-    root: 'c76ac8b52551594e251faf77137b4dcff27c9305c3ee8034d422e2ce4e1fffc2',
-    block: {
-      hash: '000000000000000000008d908fc86278cc0aa2039c5fe13e4083f7b3356ab2ef',
-      height: 880560
+      hash: '000000000000000000008346a1dd21ea24bdae2dd22a5d8264d18e0627d361fa',
+      height: 880000
     }
   }
-];
+]

--- a/test/helpers/testnet.ts
+++ b/test/helpers/testnet.ts
@@ -1,5 +1,5 @@
 import {Fabric} from '../../index';
-import {VeritasSync} from '../../veritas';
+import {AnchorStore} from '../../anchor';
 import {staticAnchors} from './anchors';
 
 interface TestnetOptions {
@@ -18,10 +18,10 @@ export default async function createTestnet(size = 10, opts: TestnetOptions = {}
 
   if (size === 0) return new Testnet(swarm);
 
-  const veritas = await VeritasSync.create({staticAnchors})
+  const anchor = await AnchorStore.create({staticAnchors})
 
   const first = new Fabric({
-    veritas: veritas,
+    anchor,
     ephemeral: false,
     // @ts-ignore
     firewalled: false,
@@ -38,7 +38,7 @@ export default async function createTestnet(size = 10, opts: TestnetOptions = {}
   while (swarm.length < size) {
     const node = new Fabric({
       // @ts-ignore
-      veritas: veritas,
+      anchor: anchor,
       ephemeral: false,
       // @ts-ignore
       firewalled: false,

--- a/test/nostr.ts
+++ b/test/nostr.ts
@@ -1,0 +1,78 @@
+import test from 'brittle'
+import {swarm} from './helpers'
+import b4a from 'b4a'
+import {serializeEvent} from '../utils';
+
+const event1 = {
+  created_at: 10000,
+  kind: 0,
+  content: 'Hello Fabric',
+  tags: [],
+  pubkey: 'dd14827a2311c54edd52fafae604bf0c1f6000febeb18833f58e10e92a2415e9',
+  id: '523cd93df6b1d9240d8199f38bc99c00941f0c3a576646aa4524e69651b40ced',
+  sig: 'd3abd6ca21a1bc6915d0309c2d1b6cc9df8c1318b88f33ed8d15e2faa7d9c29004dc36b9247433e421997fa7ae56de29d4250e36cb63786ea369c3d6760ad462'
+}
+
+const event2 = {
+  created_at: 10001,
+  kind: 0,
+  content: 'Hello Fabric 2',
+  tags: [],
+  pubkey: 'dd14827a2311c54edd52fafae604bf0c1f6000febeb18833f58e10e92a2415e9',
+  id: '55aff77beab3a92a84dd8a4ffc28e76b02a280f69ec1445313e7b5a6f1007491',
+  sig: '297a1077719bef43071720b303b5f589da68760c736eb503dfa0a5cd66cc72343ffbfc0be99ce0d5efb570887b25aaf564ea46e31e166c2ba2b4b3d7b929b35f'
+}
+
+test('nostr put - get', async function (t) {
+  const {nodes} = await swarm(t, 4)
+
+  // bad sig
+  {
+    let evt = JSON.parse(JSON.stringify(event1));
+    evt.sig = '297a1077719bef43071720b303b5f589da68760c736eb503dfa0a5cd66cc72343ffbfc0be99ce0d5efb570887b25aaf564ea46e31e166c2ba2b4b3d7b929b35f';
+
+    await t.exception (
+      nodes[0].nostrPublish(evt, {skipVerify: true})
+    );
+  }
+
+  {
+    let evt = JSON.parse(JSON.stringify(event1));
+    const put = await nodes[0].nostrPublish(evt);
+
+    t.is(put.signature.length, 64)
+
+    const pubkey = b4a.from(evt.pubkey, 'hex');
+    const sig = b4a.from(evt.sig, 'hex');
+    const res = await nodes[1].nostrGet(pubkey, evt.kind);
+
+    t.is(res.createdAt, evt.created_at)
+
+    const expected = b4a.from(serializeEvent(evt));
+    t.is(b4a.compare(res.value, expected), 0)
+    t.is(b4a.compare(res.signature, sig), 0)
+  }
+
+  // higher timestamp should override
+  {
+    let evt = JSON.parse(JSON.stringify(event2));
+    const put = await nodes[0].nostrPublish(evt);
+
+    t.is(put.signature.length, 64)
+
+    const pubkey = b4a.from(evt.pubkey, 'hex');
+    const sig = b4a.from(evt.sig, 'hex');
+    const res = await nodes[1].nostrGet(pubkey, evt.kind);
+
+    t.is(res.createdAt, evt.created_at)
+
+    const expected = b4a.from(serializeEvent(evt));
+    t.is(b4a.compare(res.value, expected), 0)
+    t.is(b4a.compare(res.signature, sig), 0)
+  }
+
+  // now publish stale event
+  {
+    await t.exception(nodes[0].nostrPublish(event1));
+  }
+})

--- a/test/nostr.ts
+++ b/test/nostr.ts
@@ -42,9 +42,8 @@ test('nostr put - get', async function (t) {
 
     t.is(put.signature.length, 64)
 
-    const pubkey = b4a.from(evt.pubkey, 'hex');
     const sig = b4a.from(evt.sig, 'hex');
-    const res = await nodes[1].nostrGet(pubkey, evt.kind);
+    const res = await nodes[1].nostrGet(evt.pubkey, evt.kind);
 
     t.is(res.createdAt, evt.created_at)
 
@@ -60,9 +59,8 @@ test('nostr put - get', async function (t) {
 
     t.is(put.signature.length, 64)
 
-    const pubkey = b4a.from(evt.pubkey, 'hex');
     const sig = b4a.from(evt.sig, 'hex');
-    const res = await nodes[1].nostrGet(pubkey, evt.kind);
+    const res = await nodes[1].nostrGet(evt.pubkey, evt.kind);
 
     t.is(res.createdAt, evt.created_at)
 

--- a/test/zone.ts
+++ b/test/zone.ts
@@ -1,102 +1,94 @@
-import test from 'brittle'
-import {swarm} from './helpers'
-import {Buffer} from 'buffer'
-import b4a from 'b4a'
-import {SignedPacket} from '../index';
+import test from 'brittle';
+import {swarm} from './helpers';
+import {serializeEvent} from '../utils';
+import {toEvent} from '../messages';
+import {DNS_EVENT_KIND} from '../constants';
 
-const test1 = {
-  serial: 1739983316,
-  space: '@buffrr',
-  packet: 'AAAoAAAAAAAABgAAB0BidWZmcnIAAAYAAgAADhAAIgRzZWxmwAwEX2Ruc8AMZ7YJ1AAADhAAAAJYAAk6gAAADhDADAABAAIAAA4QAAQBAQEBwAwAEAACAAAOEAAMC2hlbGxvIHdvcmxkwAwAEAACAAAOEAAODWhlbGxvIHdvcmxkIDHADAAQAAIAAA4QAA4NaGVsbG8gd29ybGQgMsAMABAAAgAADhAADg1oZWxsbyB3b3JsZCAz',
-  signature: '35b106c5ae422f23c0bec4d79e42d7e1cbbbb409f5462f81dc514067441bdbd3358e6e56b333a7bc8a0bea11a8784f6c4a31cf590d28f60c842020f32b6c7630',
-  proofs: {
-    recent: {
-      proof: 'AQABAALkUiXR0Ys7Dgbf3d24RYC6k6cud0lNdjZpPhjKdoqaLQEAAQAC0dYmr8jBATLigQzg6yiM7Qqst3WVN3Kw6NEI64B4WZoBAAIb4BEKG4wvg8GsbrTrEXsTVwqNhVwleNW7X1TUWcirtwEAAhGDomlXC7T7mv+UD9hyqOyxJBL7PTOLdFlGA1dn+wHmAQABAAEAAQAC1PjNPC3hnCpnUUT/MBDAeh3slDCQPpju8u53fWOioHsBAAEAAQACHKUK+r0DOuVC4W7gdPnp/9i2Yz2/Hw2b4PUgWT/DXcoAXEoSg4yLJQq893Wxbas4OFoXrYyfMyOIxE52iWHVwf8ANgEBBmJ1ZmZycgH8SR8OAAD7mgIiUSBatL1eKAsh2d/wa1zVYXCUPidDpyXSk3L4L6B7KWIaAgIRpWmm8GGiixNhqPg6hwPyPww7cIId3JdYEzeLlGnKvAIj9IoYnOeetIY5LNTgHfeaT+iGMVAWfTM1ws5WbVQFagLsms0iB5ri/QL471VBjC0Bc4oD/mzNznPK69Hc/J0vEQKaL5AibV/uH1B6kTbgwB12WBcd1DS+FlmbnuD54ue2gwJTF7byw416cFqQ8U1KU8UpJaM0HCprc//zV5QS3sSG2QKBWTux1AA5DDrsdVzihM/+u20glHAiFmML034MoX+yLQJ3lltRZKI9HVZQIn1pItgY4Wdnk/bcrSYwZOE/ILGJPw==',
-      root: 'b5be872a859411e754490d7573c7597fddae7e272166d4c4edf9c466b5ce258f',
-    },
-    optimal9th: {
-      proof: 'AQABAAKRsmHj0wljPxHaf39lOWHA4BBnvYrXHsto/Uru/E8RDQEAAQACN6GsMzPbzVQpD5p1h6/Mn+cA1Ls+gSh3WBr/S4GA6P8BAAKZSRgL4nd4KcWfgtN8yu0fV45FcQIGGEZwvhARRcU96wEAAq1P4TM1YzIkancpRHdjX8AlwhKWpaN8l7hrPESf3sXVAQABAAEAAQAC/KUWXk9v1qjBzSzrwPkwbh4YSDEq7jfEM2kHpc2bqgIBAAEAAQACHKUK+r0DOuVC4W7gdPnp/9i2Yz2/Hw2b4PUgWT/DXcoAXEoSg4yLJQq893Wxbas4OFoXrYyfMyOIxE52iWHVwf8ANgEBBmJ1ZmZycgH8SR8OAAD7mgIiUSBatL1eKAsh2d/wa1zVYXCUPidDpyXSk3L4L6B7KWIaAgKZ+CbQrn8Gb2hJmGpiL6SUk1EgoXjWeiXO517V6NtyaQKaFZsUb4eUJg7sicwldztbZkEMMBdSI/ryqXPgH39x5gK+oKrH86ouN4DR5uW/OkqrC0lrSVL3mnfP7TGDp8pxFgJsZsu6PWhFE5LRmrm7oY6vlI/iBu8bnp2lvqQcDw/7OgJPGouU4P6kuIvCcitFKAsLKPYpIQfl3B+lNsT5zUJATAJ8npoZcVHLmop6060I4QBkKN3RasEND8HFe7ppEgYwVwJ4bI9P04sYqJ9UlN0DIGwnMOVe56PWO6VvkDMHSuHBiQ==',
-      root: '5c9ff7d202f1f6498719b5f53865f7c47a34a848127590ba353aea7a7f1c52c2',
-    },
-    stale8th: {
-      proof: 'AQABAAK/RNKaiT7vtvFsTpmGG0wwQdfuL+1xlw9ClZfqD7lO9AEAAQACmrqJOM/ZYB3hgIQNYQUYX/bWnnXYCFHrQk31qXUnihsBAAJ4RhVFEUKhccEmlZrUnqxASaWL/cGxLvcUZTdOX0TH5gEAAqpUQUaFXRr4JFNA5Nu3hCHE/gTNjmy3rrrnYi833FCfAQABAAEAAQAC/KUWXk9v1qjBzSzrwPkwbh4YSDEq7jfEM2kHpc2bqgIBAAEAAQACHKUK+r0DOuVC4W7gdPnp/9i2Yz2/Hw2b4PUgWT/DXcoAXEoSg4yLJQq893Wxbas4OFoXrYyfMyOIxE52iWHVwf8ANgEBBmJ1ZmZycgH8SR8OAAD7mgIiUSBatL1eKAsh2d/wa1zVYXCUPidDpyXSk3L4L6B7KWIaAgKZ+CbQrn8Gb2hJmGpiL6SUk1EgoXjWeiXO517V6NtyaQKaFZsUb4eUJg7sicwldztbZkEMMBdSI/ryqXPgH39x5gK+oKrH86ouN4DR5uW/OkqrC0lrSVL3mnfP7TGDp8pxFgKPxIOKvgCIfi3pNhjGIYMxJ3sXuTmz/Mdu07fFCr/kIgIRfTIFiskImX4ZRZOC2whdDG2WBAIgZkAQj/AaOUm1PgKs2EjIl9IuhqXQb3ujEVg8JmKktt571Q6FgTG1FL/LJwKdYDEaT9VzHtjnIvjgqJTN20EEPIeVVWtTPCdW7UvS1A==',
-      root: '12de6d90515302d465bb3886574351b3d730998e9fbc3b10ac19e2467b2908ec'
-    },
-    stale5th: {
-      proof: 'AQABAALRAHUsA2gw/fXpfWQuuZMPruDTzgr6qhBdWGTmMRGJiQEAAQACAL0WTz3NA7A/PU7b7dKZYQiLXb84eQSt/j9irbXCUkABAALJhHFi87fgi7HNKUQVSZdQsQ9/esiGgLs+ErPLFD1AuwEAAjpT42ux/siFb77egwmTSy+A7qX0mW7R55e2S4g8zvoyAQABAAEAAQAC/KUWXk9v1qjBzSzrwPkwbh4YSDEq7jfEM2kHpc2bqgIBAAEAAQACHKUK+r0DOuVC4W7gdPnp/9i2Yz2/Hw2b4PUgWT/DXcoAXEoSg4yLJQq893Wxbas4OFoXrYyfMyOIxE52iWHVwf8ANgEBBmJ1ZmZycgH8SR8OAAD7mgIiUSBatL1eKAsh2d/wa1zVYXCUPidDpyXSk3L4L6B7KWIaAgKZ+CbQrn8Gb2hJmGpiL6SUk1EgoXjWeiXO517V6NtyaQLuzl2S7G3nuLmBmIfiqesWdRC79QCAd8xDquxQVl9zfgK+oKrH86ouN4DR5uW/OkqrC0lrSVL3mnfP7TGDp8pxFgKtSGMdliTCj8MtkQ7/puJoTkkqUDHEinBd8eKz923dVQIRfTIFiskImX4ZRZOC2whdDG2WBAIgZkAQj/AaOUm1PgKMIUB7DgNUAnghwMce+1xn2o2z/4zHfWaXrQLiMSyK4QLJWi3mGsmKTydvje6Q2x4i/biAXO+m1bgmRUpUVvh+dg==',
-      root: 'ee6bc6e95bf8d28de119c7973106fdb8a78057eab21238a25d0140f53c49a9ec'
-    }
-  }
+const event1 = {
+  id: 'b484ffb45b5494d27b3dadf9f7b0b8c3b1e2014189df07a122af7d8dc2cdfd4b',
+  pubkey: 'd85391f4c095368da0f40a16c3aa92ae4afd0bf9e4c5192ea8c003ed0a8ca83a',
+  created_at: 1740973309,
+  kind: DNS_EVENT_KIND,
+  tags: [['space', '@buffrr']],
+  content: 'AAAoAAAAAAAAAwAAB0BidWZmcnIAAAYAAgAADhAAFgAAAAAAAQAADhAAAAJYAAk6gAAADhDADAAQAAIAAA4QABAPSGVsbG8gRmFicmljIDIhCF9kbnNsaW5rwAwAEAACAAABLABRUGRuc2xpbms9L2ZhYnJpYy82NDEwZDY2OGI3M2EyYWY4MzRmYjYyNGM3YTIzODE3YjQ5YWNhNmIyY2M2MGY3ODI1N2ViNDhjZGIzNWY1MDNi',
+  sig: 'cd23558b4ade4d77def66577b77f39e6fedab2e32e62bfce3b7f93eb40e3cf9e0b23cb1e1565432ffdadef80ed0711a0943b11207aa19ee029b56f7fd3536025',
+  proof: 'AQABAAICaQ4Hhr08OtNDZZkSgTXGk0i3MfIoALf8cucZSnhUyQEAAgHMqhn+t6Kt9nwQ8ITKZcR0r5JTbQCYDoodIJu3BgJXAQACshSYdNudO8PZpcHCUfUeA1nf6dsQKOrwdlKQ6VK2cREBAALOGDW46g0yOtskXbr+scDDV3isVBs3o0hdtgQjg50mtQEAAQACpmbW21sw1Zs9yCL/opL/AfWCT+jpAo/V3Jv8IwkAAKQBAAEAAQABAAKopnVk/YV2oYV25GtcLayl5ni32Emhp9BZJhI+ztaowgECAAEAAnbnjD/E70jXov9+lUNkoAcwKQPjzUk/RSdwr8OASc2jAHojU547PodMGx8rInYvFf07BGPlgmQ1o0MO3E8bkaR5ADYBAQZidWZmcnIB/P1NDgAA+5oCIlEg2FOR9MCVNo2g9AoWw6qSrkr9C/nkxRkuqMAD7QqMqDoCOR0jY/cxeZtcXiCqcPb8DeIMN5+WSZBE1kglChNFY0wC8BQD5SlPmF3Vhhw+KQ1zdep3MrLhwQn+h5LTYgQLI3ICbzK4OrJ6bw0yMxwJtyKahf0ZgEAwasb2B3GZWrj3jQECThG5kQ7Cp/jWc4rNIFGydGVDgFuGcxKQJjmuOpLvx2UC/zkE8JjXl+fav1x3w3cUugn6Vp1v/GyFXDMZuNpyWNcCE80cksYPRzx2WwIV74fjyKU1GTT/cqCaj38YUSwNKMg='
+};
+
+const event2 = {
+  id: '020ea34e1fdf02acda596127be3629d2628e49535a056efed18161359bdfc7bb',
+  pubkey: '374edebe2cc448fc4ebcd46b99322a0373c7c905cec227ae1ce8773ca616de81',
+  created_at: 1740975447,
+  kind: DNS_EVENT_KIND,
+  tags: [ ['space', '@key']],
+  content: 'AAAoAAAAAAAAAwAAB0BidWZmcnIAAAYAAgAADhAAFgAAAAAAAQAADhAAAAJYAAk6gAAADhDADAAQAAIAAA4QABAPSGVsbG8gRmFicmljIDIhCF9kbnNsaW5rwAwAEAACAAABLABRUGRuc2xpbms9L2ZhYnJpYy82NDEwZDY2OGI3M2EyYWY4MzRmYjYyNGM3YTIzODE3YjQ5YWNhNmIyY2M2MGY3ODI1N2ViNDhjZGIzNWY1MDNi',
+  sig: '27da4643383feb29f4b88f88cc7401b9acf4d46b47e8cc16db3b35afed29c402d5eb79728fbe7c16c624a78d558bae8e99c76474278a3fa40060dee08fa1abaa',
+  proof: 'AQABAAEAAuWfRJiigs/m7dfDuNZvssGZjxAPxwhxaY/GrCgc0NlwAQABAALcgUjhk30jWjMJ2i4jaqn1uIoq8JsRX4k9dbP7fWx/3AEAAQACQQMTow6+qMIDLAOGdZps9Zo3p9NtCupnVgHD+UviiCcBAAEAAkdpXwG20X/B75E5XZnCdJBe1pXJ3TO2WZBGPgYTaMRwAQACum23ooo9fyF6fqw5lxOiKS9Jx8dyzkmIXi3pTiPuEm0BAALle+SLsgn36U4romjVGZ4uLaUVb2H2Ddf6/GDF6m55qAEDAAJ+YuqBgvNzZzSpztzOIwN3m4ArnRWMmQEs/tzvpxXV5QAq47VeiOhRPDzkDjkx23DUvT6fiMoA2cCCj9x5baS5AQAzAQEDa2V5AfyQPw4AAPuaAiJRIDdO3r4sxEj8TrzUa5kyKgNzx8kFzsInrhzodzymFt6BAh9VzKiTxnkXIC/XdnoTz+bF8fvVeZ821l3qwTRvtdF2AnMLhv+r0Ff9rS4E+ruR8otqQeelA1VHWuTDmXuDf0/TAmIq119D2MAoTEzqzuEYY1ORRZfrYUFcEr1P+IKkn2mfAqSS0lyizvxxs7GGuV5dX5q3yZ6hNs1nxdzWLsON741uAsbQwq18YYXJ2sg5fvMI8Ye3W8J+EX/3xpSHPwIADtYB'
+};
+
+const event2_recent = {
+  id: '81ce23a31ac3451a5b64d239f9484e6e51dd69d150f2746fd1fed2a88fa829dd',
+  pubkey: '374edebe2cc448fc4ebcd46b99322a0373c7c905cec227ae1ce8773ca616de81',
+  created_at: 1740975646,
+  kind: DNS_EVENT_KIND,
+  tags: [['space', '@key']],
+  content: 'AAAoAAAAAAAAAwAAB0BidWZmcnIAAAYAAgAADhAAFgAAAAAAAQAADhAAAAJYAAk6gAAADhDADAAQAAIAAA4QABAPSGVsbG8gRmFicmljIDIhCF9kbnNsaW5rwAwAEAACAAABLABRUGRuc2xpbms9L2ZhYnJpYy82NDEwZDY2OGI3M2EyYWY4MzRmYjYyNGM3YTIzODE3YjQ5YWNhNmIyY2M2MGY3ODI1N2ViNDhjZGIzNWY1MDNi',
+  sig: '623d762b64bb39f4ac9b2ef0652ffe9d256439dc6cff3258139036c7a8981ea024ea94859223ca70190cd5a45fcb09f760427acf2008f2e26628f521d2d6b6dd',
+  proof: 'AQABAAEAAqVmFJzDMpAtx1mou0EhNkDuJc+Rs2BwJkXCYMXRV297AQABAAIfUWVF7lB8aJ2KdD/gA0r9WoxK9hG5Br0vfEGS2aQ1dgEAAQACfMnO2IuEKMQrOKpDQBuP8HocSSeR7EUNER/wg2ZrvSYBAAEAArvWh1+Owi7o2NysahbLZIzQEI1G1S7/ZI5jOGNUW5tdAQACUXlHkfpR0MxoCqjpQLJLSz9L7SHROI9VztexNBeknn8BAALuraW48cEmXqTpp+kXun8wA2GA5NBlCSMBEcsWlvc2CwEDAALMt+Xeec4SMGN4X5D3KsHZxYKKSN7N7ujZNC+dEhcKIAAq47VeiOhRPDzkDjkx23DUvT6fiMoA2cCCj9x5baS5AQAzAQEDa2V5AfyQPw4AAPuaAiJRIDdO3r4sxEj8TrzUa5kyKgNzx8kFzsInrhzodzymFt6BAtfJq8ewSbKHn47fxfyyW3ELuGXODaswvKynZ8Hd2s+aAvr6vdplu/RXFexPmJkS/nkbW+R55ZuWxyf6ZainbxmFAlzo0/fm4pOCnSX943NxLqzHM735dB8Ysk8jIVZsImI1AoTfdC+s8xIuT4xoO2lyjE75bu/xiAcwU2AqjsROxTP7AhdYuvoh4eJhpyue4rHJO10IFgDZbiRaDLVX/YuoSSFT'
+};
+
+const event2_recent_pubkey_changed = {
+  id: 'c79f6700c772fc5ec1cc84503ccd389f31f836f87a0b84911a1cf152d14da1d1',
+  pubkey: '8da4134b2be6c0313ec56ee55771f5cd73ee623e40e980fff9f24b0371197539',
+  created_at: 1741004331,
+  kind: DNS_EVENT_KIND,
+  tags: [['space', '@key']],
+  content: 'AAAoAAAAAAAAAwAAB0BidWZmcnIAAAYAAgAADhAAFgAAAAAAAQAADhAAAAJYAAk6gAAADhDADAAQAAIAAA4QABAPSGVsbG8gRmFicmljIDIhCF9kbnNsaW5rwAwAEAACAAABLABRUGRuc2xpbms9L2ZhYnJpYy82NDEwZDY2OGI3M2EyYWY4MzRmYjYyNGM3YTIzODE3YjQ5YWNhNmIyY2M2MGY3ODI1N2ViNDhjZGIzNWY1MDNi',
+  sig: 'b75bec3f8eaa3a0c2bb5b89d345ad09e6288717d01acf5945980c4781d9d8383e0e130da94fc559007338d775638effb0295792f7755bf3202f49d587f18fb44',
+  proof: 'AQABAAEAAqVmFJzDMpAtx1mou0EhNkDuJc+Rs2BwJkXCYMXRV297AQABAAKjLGAMwDd2cpgBE3kFXi5g+5HxIHdWOkXqot/lfxammwEAAncXvli12w/dd0CZe7YQmei05aegK+PgK2IM42IHvN9/AQABAAEAAivuZvjtgxH863DqJ0X09yDXS+OhsATdSzkkdtda7isyAQACPZ+PndQVQO0KL/SCOdHPoEIIbyCbom3Nd4mTkDOuw0sBAAKAnpXjnJxu2mDM2CXGl/VycDiRdG7NxUR5QEJ5RXX6JgEAAlEMyaJt3AEkcmNh6rCQS4PS0dQWBc+RT2QsXhqOEISxACzz3GaYf+A1jc05T5j9d9TUgJEHWHdBfjA0lx0MF9lTADMBAQNrZXkB/JJSDgAA+5oCIlEgjaQTSyvmwDE+xW7lV3H1zXPuYj5A6YD/+fJLA3EZdTkCGAi1GnsbUBMjlEJAiKBhk/bIgJ/xwQVjQ+X3FoG4tX0CBQpb0tbgScRiFr+8B9qylGHXmld8ooJE4+VHxm0AywcCXOjT9+bik4KdJf3jc3EurMczvfl0HxiyTyMhVmwiYjUC87iQT7ZO27G45qboYxf2/uPQuWL13YLhp6UhEhKktpgCF1i6+iHh4mGnK57isck7XQgWANluJFoMtVf9i6hJIVM='
 }
 
-function getPacket(proofVersion: string): SignedPacket {
-  // @ts-ignore
-  const proof = test1.proofs[proofVersion].proof
-  if (!proof) throw new Error(`no '${proofVersion}' found in test data`);
-
-  return {
-    proof: Buffer.from(proof, 'base64'),
-    space: test1.space,
-    serial: test1.serial,
-    signature: Buffer.from(test1.signature, 'hex'),
-    value: Buffer.from(test1.packet, 'base64')
-  }
-}
-
-test('zone put - get', async function (t) {
+test('space put - gets', async function (t) {
   const {nodes} = await swarm(t, 4)
 
-  // should validate signature
-  let pkt = getPacket('stale5th')
-  pkt.signature = Buffer.alloc(64);
-  await t.exception(
-    nodes[0].zonePublish(pkt)
-  );
+  {
+    let evt = JSON.parse(JSON.stringify(event1));
+    const put = await nodes[0].eventPut(evt);
 
-  // should validate space name
-  pkt = getPacket('stale5th')
-  pkt.space = '@wrongspace';
-  await t.exception(
-    nodes[0].zonePublish(pkt)
-  );
-  
-  // should accept stale proof if no alternative exists
-  const stale = getPacket('stale5th')
-  const put = await nodes[0].zonePublish(stale)
+    t.is(serializeEvent(toEvent(put.event)), serializeEvent(evt));
 
-  t.is(put.signature.length, 64)
+    const res = await nodes[1].eventGet('@buffrr', evt.kind);
 
-  const res = await nodes[1].zoneGet(stale.space)
+    t.is(serializeEvent(toEvent(res.event)), serializeEvent(evt));
+  }
 
-  t.is(res.serial, stale.serial)
-  t.is(b4a.compare(res.value, stale.value), 0)
-  t.is(b4a.compare(res.proof, stale.proof), 0)
-  t.is(b4a.compare(res.signature, put.signature), 0)
-  t.is(typeof res.from, 'object')
-  t.is(typeof res.from.host, 'string')
-  t.is(typeof res.from.port, 'number')
-  t.is(typeof res.to, 'object')
-  t.is(typeof res.to.host, 'string')
+  {
+    let evt = JSON.parse(JSON.stringify(event2));
+    const put = await nodes[0].eventPut(evt);
 
-  // if both proofs are stale, it should accept the more recent one
-  const stale8th = getPacket('stale8th')
-  await nodes[0].zonePublish(stale8th)
+    t.is(serializeEvent(toEvent(put.event)), serializeEvent(evt));
 
-  // a more recent proof can override a stale proof
-  const recent = getPacket('recent')
-  const put2 = await nodes[0].zonePublish(recent)
+    const res = await nodes[1].eventGet('@key', evt.kind);
+    t.is(serializeEvent(toEvent(res.event)), serializeEvent(evt));
 
-  t.is(put2.signature.length, 64)
+    const res2 = await nodes[1].eventGet('@buffrr', evt.kind);
+    t.is(serializeEvent(toEvent(res2.event)), serializeEvent(event1));
+  }
 
-  const res2 = await nodes[1].zoneGet(recent.space)
-  t.is(b4a.compare(res2.proof, recent.proof), 0)
+  // more recent proof shouldn't be accepted
+  {
+    let evt = JSON.parse(JSON.stringify(event2_recent));
+    await t.exception (nodes[0].eventPut(evt))
+  }
 
-  // an optimal proof can override a more recent proof
-  const optimal = getPacket('optimal9th')
-  await nodes[0].zonePublish(optimal)
-  const res3 = await nodes[1].zoneGet(optimal.space)
-  t.is(b4a.compare(res3.proof, optimal.proof), 0)
+  // however if pubkey changed we should accept it
+  {
+    let evt = JSON.parse(JSON.stringify(event2_recent_pubkey_changed));
+    const put = await nodes[0].eventPut(evt);
 
-  // a more recent proof cannot override an optimal proof
-  await t.exception(nodes[0].zonePublish(recent))
+    t.is(serializeEvent(toEvent(put.event)), serializeEvent(evt));
+
+    const res = await nodes[1].eventGet('@key', evt.kind);
+    t.is(serializeEvent(toEvent(res.event)), serializeEvent(evt));
+  }
 })

--- a/utils.ts
+++ b/utils.ts
@@ -123,3 +123,8 @@ export function verifyTarget(evt: CompactEvent, target: Uint8Array): TargetInfo 
     return null
   }
 }
+
+export function log(...args: any[]): void {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}]`, ...args);
+}

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import b4a from 'b4a';
 
 export function spaceHash(spaceName: string): Buffer {
   const label = spaceName.startsWith('@') ? spaceName.slice(1) : spaceName;
@@ -11,3 +12,76 @@ export function spaceHash(spaceName: string): Buffer {
   return base;
 }
 
+// from nostr-tools:
+// https://github.com/nbd-wtf/nostr-tools/blob/160987472fd4922dd80c75648ca8939dd2d96cc0/event.ts#L42
+export type NostrEvent = {
+  id?: string
+  sig?: string
+  kind: number
+  tags: string[][]
+  pubkey: string
+  content: string
+  created_at: number
+}
+
+// from nostr-tools:
+// https://github.com/nbd-wtf/nostr-tools/blob/160987472fd4922dd80c75648ca8939dd2d96cc0/event.ts#L61
+export function validateEvent(event: NostrEvent): boolean {
+  if (typeof event.content !== 'string') return false
+  if (typeof event.created_at !== 'number') return false
+  if (typeof event.pubkey !== 'string') return false
+  if (!event.pubkey.match(/^[a-f0-9]{64}$/)) return false
+
+  if (!Array.isArray(event.tags)) return false
+  for (let i = 0; i < event.tags.length; i++) {
+    let tag = event.tags[i]
+    if (!Array.isArray(tag)) return false
+    for (let j = 0; j < tag.length; j++) {
+      if (typeof tag[j] === 'object') return false
+    }
+  }
+  return true
+}
+
+// from nostr-tools:
+// https://github.com/nbd-wtf/nostr-tools/blob/160987472fd4922dd80c75648ca8939dd2d96cc0/event.ts#L42
+export function serializeEvent(evt : NostrEvent) {
+  if (!validateEvent(evt))
+    throw new Error("can't serialize event with wrong or missing properties");
+
+  return JSON.stringify([
+    0,
+    evt.pubkey,
+    evt.created_at,
+    evt.kind,
+    evt.tags,
+    evt.content,
+  ]);
+}
+
+export function deserializeEvent(serialized: string): NostrEvent {
+  let arr: any;
+  try {
+    arr = JSON.parse(serialized);
+  } catch (e) {
+    throw new Error('Invalid Nostr event JSON string');
+  }
+
+  if (!Array.isArray(arr) || arr.length !== 6 || arr[0] !== 0) {
+    throw new Error('Serialized event has an invalid format');
+  }
+  const [, pubkey, created_at, kind, tags, content] = arr;
+  return { pubkey, created_at, kind, tags, content };
+}
+
+
+export function nostrDTag(tags : any) : string {
+  if (!Array.isArray(tags)) return ''
+  const tag = (tags as any[]).find(tag => Array.isArray(tag) && tag[0] === 'd' && typeof tag[1] === 'string')
+  if (!tag) return '';
+  return tag
+}
+
+export function nostrTarget(pubkey: string, kind: number, d : string = '') : string {
+  return `${pubkey}${kind}${d}`;
+}


### PR DESCRIPTION
This PR unifies the signing format for Spaces by adopting Nostr events across all messages. It updates Fabric to support two lookup types using Nostr events:

1. **Forward Lookups (`space`)**:  
   - Key: `SHA256(SHA256(space) || <event kind> || <optional-d-tag>)` -> Nostr event.  
   - DNS records use `kind: 871222` for now.

2. **Reverse Lookups (`npub`)**:  
   - Key: `SHA256(npub || <event kind> || <optional-d-tag>)` -> Nostr event.

Currently, Fabric accepts all replaceable (0, 3, 30000 .. < 40000) and addressable (10000 .. < 20000) event kinds, and 871222.

