### PR TITLE
fix for local anchors 

### DIFF
--- a/anchor.ts
+++ b/anchor.ts
@@ -12,11 +12,17 @@ interface Anchor {
     };
 }
 
+interface BasicAuthConfig {
+    username: string;
+    password: string;
+}
+
 interface UpdateOptions {
     localPath?: string;        // Local file
     remoteUrls?: string[];     // Remote endpoints to fetch anchor file
     staticAnchors?: Anchor[];  // Use the following static anchors
     checkIntervalMs?: number;  // Periodic refresh
+    basicAuth?: BasicAuthConfig;
 }
 
 export class AnchorStore {
@@ -198,12 +204,59 @@ export class AnchorStore {
     return null;
   }
 
+  private extractAuthFromUrl(url: string): { username: string; password: string } | null {
+    try {
+      const urlObj = new URL(url);
+      if (urlObj.username && urlObj.password) {
+        return {
+          username: decodeURIComponent(urlObj.username),
+          password: decodeURIComponent(urlObj.password)
+        };
+      }
+    } catch (err) {
+      log(`Invalid URL format: ${url}`);
+    }
+    return null;
+  }
+
+  private cleanUrl(url: string): string {
+    try {
+      const urlObj = new URL(url);
+      urlObj.username = '';
+      urlObj.password = '';
+      return urlObj.toString();
+    } catch (err) {
+      log(`Invalid URL format: ${url}`);
+      return url;
+    }
+  }
+
+  private createAuthHeaders(url: string): HeadersInit {
+    const headers: HeadersInit = {};
+    const authFromUrl = this.extractAuthFromUrl(url);
+    if (authFromUrl) {
+      const credentials = Buffer.from(`${authFromUrl.username}:${authFromUrl.password}`).toString('base64');
+      headers['Authorization'] = `Basic ${credentials}`;
+    } else if (this.options.basicAuth) {
+      const { username, password } = this.options.basicAuth;
+      const credentials = Buffer.from(`${username}:${password}`).toString('base64');
+      headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    return headers;
+  }
+
   private async fetchAnchorsFromRemotes(remoteUrls: string[]): Promise<Anchor[]> {
     const responses = await Promise.all(
       remoteUrls.map(async url => {
         log(`Fetching anchors from: ${url}`);
         try {
-          const res = await fetch(url);
+          const authHeaders = this.createAuthHeaders(url);
+          const cleanUrl = this.cleanUrl(url);
+
+          const res = await fetch(cleanUrl, {
+            headers: authHeaders
+          });
           if (!res.ok) {
             throw new Error(`Status: ${res.status}`);
           }
@@ -238,9 +291,9 @@ export class AnchorStore {
     for (const group of groups.values()) {
       if (
         !chosen ||
-                group.count > chosen.count ||
-                (group.count === chosen.count &&
-                    group.anchors[0].block.height > chosen.anchors[0].block.height)
+        group.count > chosen.count ||
+      (group.count === chosen.count &&
+       group.anchors[0].block.height > chosen.anchors[0].block.height)
       ) {
         chosen = group;
       }
@@ -250,6 +303,7 @@ export class AnchorStore {
     }
     return chosen.anchors;
   }
+
 
   public isStale(version: number): boolean {
     return version < this.staleThreshold;

--- a/bin/common.ts
+++ b/bin/common.ts
@@ -56,16 +56,19 @@ export async function nodeOpts(opts: MainOptions): Promise<FabricOptions> {
 
 export async function anchorFromOpts(opts: MainOptions): Promise<AnchorStore> {
   const localAnchors = opts.localAnchors || process.env.FABRIC_LOCAL_ANCHORS;
-  const remoteAnchors =
-        opts.remoteAnchors ||
-        (process.env.FABRIC_REMOTE_ANCHORS
-          ? process.env.FABRIC_REMOTE_ANCHORS.split(',')
-          : ['http://127.0.0.1:7225/root-anchors.json']);
+  const remoteAnchors = opts.remoteAnchors || (process.env.FABRIC_REMOTE_ANCHORS ? process.env.FABRIC_REMOTE_ANCHORS.split(',') : undefined);
 
-  return AnchorStore.create({
-    localPath: localAnchors,
-    remoteUrls: remoteAnchors,
-  });
+  const updateOptions: any = {};
+
+  if (localAnchors) {
+    updateOptions.localPath = localAnchors;
+  } else if (remoteAnchors) {
+    updateOptions.remoteUrls = remoteAnchors;
+  } else {
+    updateOptions.remoteUrls = ['http://127.0.0.1:7225/root-anchors.json'];
+  }
+
+  return AnchorStore.create(updateOptions);
 }
 
 export function joinHostPort(address: Address | null): string {


### PR DESCRIPTION
It's impossible to run fabric with local root anchors file:

```bash
$ fabric --local-anchors rootanchors.json
Must specify exactly one of local, remote, or static anchors.
```

It always sets remote anchors even if they were not provided. But later there is a check whether only 1 options was used:
```javascript
  private constructor(private options: UpdateOptions) {
    const usingLocal = !!options.localPath;
    const usingRemote = !!options.remoteUrls;
    const usingStaticAnchors = !!options.staticAnchors;

    if ([usingLocal, usingRemote, usingStaticAnchors].filter(Boolean).length != 1) {
      throw new Error('Must specify exactly one of local, remote, or static anchors.');
    }
```
